### PR TITLE
Refactor calc_checksum to crc_checksum module

### DIFF
--- a/d_rats/crc_checksum.py
+++ b/d_rats/crc_checksum.py
@@ -1,0 +1,70 @@
+'''CRC Checksum.'''
+#
+# Copyright 2008 Dan Smith <dsmith@danplanet.com>
+# Copyright 2021-2022 John. E. Malmberg - Python3 Conversion
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+def _update_crc(c_byte, crc):
+    '''
+    Update the CRC.
+
+    :param c_byte: Character byte to add
+    :type c_byte: int
+    :param crc: CRC to update
+    :type crc: int
+    :returns: 16 bit CRC
+    :rtype: int
+    '''
+    # python 2 compatibility hack
+    # :type c_byte: may be str for python2
+    if isinstance(c_byte, str):
+        c_byte = ord(c_byte)
+    for _ in range(0, 8):
+        c_byte <<= 1
+
+        if (c_byte & 0o400) != 0:
+            value = 1
+        else:
+            value = 0
+
+        if crc & 0x8000:
+            crc <<= 1
+            crc += value
+            crc ^= 0x1021
+        else:
+            crc <<= 1
+            crc += value
+
+    return crc & 0xFFFF
+
+
+def calc_checksum(data):
+    '''
+    Calculate a checksum
+
+    :param data: Data to checksum
+    :type data: bytes
+    :returns: checksum
+    :rtype: int
+    '''
+    # :type data: is str for python2
+    checksum = 0
+    for i in data:
+        checksum = _update_crc(i, checksum)
+
+    checksum = _update_crc(0, checksum)
+    checksum = _update_crc(0, checksum)
+    return checksum

--- a/d_rats/wl2k.py
+++ b/d_rats/wl2k.py
@@ -1,8 +1,6 @@
 '''WL2K.'''
 # pylint wants only 1000 lines per module
 # pylint: disable=too-many-lines
-from __future__ import absolute_import
-from __future__ import print_function
 
 import logging
 import os
@@ -23,13 +21,11 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import GLib
 from gi.repository import GObject
 
-# sys.path.insert(0, "..")
-
 from d_rats import version
 from d_rats import dplatform
 from d_rats import formgui
 from d_rats import signals
-from d_rats.ddt2 import calc_checksum
+from d_rats.crc_checksum import calc_checksum
 from d_rats import agw
 from d_rats.dratsexception import DataPathIOError
 
@@ -341,6 +337,7 @@ class WinLinkMessage:
         try:
             body_length = int(body)
         except ValueError:
+            # pylint: disable=raise-missing-from
             raise Wl2kMessageHeaderError(
                 "Error parsing Body header length `%s'" % body)
 
@@ -656,6 +653,7 @@ class WinLinkCMS:
         try:
             _sw, _ver, _caps = recv_ssid[1:-1].split(b"-")
         except ValueError:
+            # pylint: disable=raise-missing-from
             raise Wl2kCMSBadSSID(
                 "Conversation error (unparsable SSID `%s')" % recv_ssid)
 
@@ -842,6 +840,7 @@ class WinLinkTelnet(WinLinkCMS):
         try:
             _sw, _ver, _caps = resp[1:-1].split(b"-")
         except ValueError:
+            # pylint: disable=raise-missing-from
             raise Wl2kCMSBadSSID(
                 "Conversation error (unparsable SSID `%s')" % resp)
 
@@ -1146,6 +1145,7 @@ def test_agw_server(host="127.0.0.1", port=8000):
     logger = logging.getLogger("wl2k_test_agw_server")
     # Quick and dirty simulator for agwpe unit tests.
     logger.info("test_server: starting %s:%i", host, port)
+    # pylint: disable=import-outside-toplevel
     from time import sleep
 
     ssid = WinLinkCMS.ssid() + b'\r'
@@ -1199,6 +1199,7 @@ def main():
 
     logger = logging.getLogger("wl2k_test")
 
+    # pylint: disable=import-outside-toplevel
     from time import sleep
     server = threading.Thread(target=test_agw_server)
     server.start()

--- a/libexec/lzhuf.c
+++ b/libexec/lzhuf.c
@@ -1105,7 +1105,7 @@ int send_yapp(int usock, struct fwd *f, char *subj, int b2f)
       oFile = fopen(f->oFile, "rb");
 
 #ifdef LZHDEBUG
-         printf("we opended %s for input.\n",  f->oFile);
+         printf("we opened %s for input.\n",  f->oFile);
 #endif
 
       // Grab some space. Largest YAPP packet is 250+ bytes.


### PR DESCRIPTION
The calc_checksum is used by multiple modules, so should be in its own module.

d_rats/crc_checksum: (new)
  calc_checksum moved from d_rats/ddt2.py

d_rats/ddt2.py:
  Remove calc_checksum function.
  Remove useless shebang and python2 import future.
  Renamed some variables from being marked as "unused" with a "_" prefix.

d_rats/wl2k.py:
  Change calc_checksum import.
  Remove useless shebang and python2 import future.