### PR TITLE
Start of dplatform cleanup

### DIFF
--- a/d-rats.py
+++ b/d-rats.py
@@ -35,7 +35,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 from d_rats.version import __version__
-from d_rats import dplatform
+from d_rats.dplatform import Platform
 
 
 # Default gettext function which is needed for pylance
@@ -124,7 +124,7 @@ possible.
             IGNORE_ALL = True
             break
         if response == Gtk.ResponseType.HELP:
-            platform = dplatform.get_platform()
+            platform = Platform.get_platform()
             platform.open_text_file(platform.config_file("debug.log"))
 
 
@@ -142,7 +142,7 @@ def uninstall_excepthook():
 def main():
     '''D-Rats Main module.'''
 
-    platform = dplatform.get_platform()
+    platform = Platform.get_platform()
     def_config_dir = platform.config_dir()
 
     # pylint wants at least 2 public methods, but we do not need them
@@ -208,9 +208,10 @@ def main():
         platform.set_config_dir(args.config)
 
     # import the D-Rats main application
+    # pylint: disable=import-outside-toplevel
     from d_rats import mainapp
 
-    # stores away the value of sys.excepthook
+     # stores away the value of sys.excepthook
     install_excepthook()
 
     # create the mainapp with the basic options
@@ -222,6 +223,8 @@ def main():
     # see what happens)
     if args.profile:
         MODULE_LOGGER.info("main: Executing with cprofile")
+        # Contrary to pylint, we do not want to import this unless needed.
+        # pylint: disable=import-outside-toplevel
         import cProfile
         cProfile.runctx('app.main()', globals(), locals())
     else:

--- a/d-rats_repeater.py
+++ b/d-rats_repeater.py
@@ -23,6 +23,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import argparse
 import ast
 import logging
 import os
@@ -43,7 +44,7 @@ from gi.repository import Gtk
 from gi.repository import GObject
 
 from d_rats.version import __version__
-from d_rats import dplatform
+from d_rats.dplatform import Platform
 from d_rats import transport
 from d_rats import comm
 from d_rats.miscwidgets import make_choice
@@ -321,7 +322,7 @@ class Repeater:
             pipe.write(b"100 Authentication not required for localhost\r\n")
             return True
 
-        auth_fname = dplatform.get_platform().config_file("users.txt")
+        auth_fname = Platform.get_platform().config_file("users.txt")
         try:
             auth = open(auth_fname)
             lines = auth.readlines()
@@ -339,7 +340,7 @@ class Repeater:
             try:
                 user, passwd = line.split(" ", 1)
                 user = user.upper()
-            except ValueError as err:
+            except ValueError:
                 self.logger.info("auth_user: Failed to parse "
                                  "line %i in users.txt: %s",
                                  lno, line)
@@ -421,6 +422,7 @@ class Repeater:
     def repeat(self):
         '''Repeat.'''
         self.repeat_thread = threading.Thread(target=self._repeat)
+        # pylint: disable=deprecated-method
         self.repeat_thread.setDaemon(True)
         self.repeat_thread.start()
 
@@ -453,7 +455,7 @@ class RepeaterUI:
         self.tap = None
         self.tick = 0
 
-        self.platform = dplatform.get_platform()
+        self.platform = Platform.get_platform()
         self.config = self.load_config()
 
     def load_config(self):
@@ -939,8 +941,7 @@ class RepeaterGUI(RepeaterUI):
             :param _button: Button Widget signaled, unused
             :type _button: :class:`Gtk.Button`
             '''
-            platform = dplatform.get_platform()
-            platform.open_text_file(platform.config_file("users.txt"))
+            self.platform.open_text_file(self.platform.config_file("users.txt"))
 
         edit_users = Gtk.Button.new_with_label("Edit Users")
         edit_users.connect("clicked", clicked_edit_users)
@@ -1214,8 +1215,6 @@ class RepeaterConsole(RepeaterUI):
 def main():
     '''D-Rats Repeater main program.'''
 
-    import argparse
-
     gettext.install("D-RATS")
     lang = gettext.translation("D-RATS",
                                localedir="locale",
@@ -1225,7 +1224,7 @@ def main():
     global _
     _ = lang.gettext
 
-    platform = dplatform.get_platform()
+    platform = Platform.get_platform()
     def_config_dir = platform.config_dir()
 
     # pylint wants at least 2 public methods, but we do not need them

--- a/d_rats/emailgw.py
+++ b/d_rats/emailgw.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 '''Email Gateway.'''
 #
 # Copyright 2008 Dan Smith <dsmith@danplanet.com>
@@ -17,9 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import logging
 import os
 import threading
@@ -36,7 +32,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import GObject
 from gi.repository import GLib
 
-from . import dplatform
+from .dplatform import Platform
 from . import formgui
 from .ui import main_events
 from . import signals
@@ -99,10 +95,10 @@ def create_form_from_mail(config, mail, tmpfn):
         for part in mail.walk():
             if part.get_content_maintype() == "multipart":
                 continue
-            elif part.get_content_type() == "d-rats/form_xml":
+            if part.get_content_type() == "d-rats/form_xml":
                 xml = str(part.get_payload())
                 break # A form payload trumps all
-            elif part.get_content_type() == "text/plain":
+            if part.get_content_type() == "text/plain":
                 body += part.get_payload(decode=True)
             elif part.get_content_type() == "text/html":
                 html = part.get_payload(decode=True)
@@ -223,7 +219,7 @@ class MailThread(threading.Thread, GObject.GObject):
         ident = self.config.get("user", "callsign") + \
             time.strftime("%m%d%Y%H%M%S") + \
             mail.get("Message-id", str(random.randint(0, 1000)))
-        mid = dplatform.get_platform().filter_filename(ident)
+        mid = Platform.get_platform().filter_filename(ident)
         ffn = os.path.join(self.config.form_store_dir(),
                            _("Inbox"),
                            "%s.xml" % mid)
@@ -355,6 +351,7 @@ class AccountMailThread(MailThread):
             host, user, pasw, poll, ssl, port, action, enb = \
                 settings.split(",", 7)
         except ValueError:
+            # pylint: disable=raise-missing-from
             raise BadAccountSettingsError(
                 "Unable to parse account settings for `%s'" %
                 account)
@@ -367,6 +364,7 @@ class AccountMailThread(MailThread):
         try:
             self.__action = actions[action]
         except KeyError:
+            # pylint: disable=raise-missing-from
             raise UnsupportedActionError("Unsupported action `%s' for %s@%s" %
                                          (action, user, host))
 
@@ -398,7 +396,7 @@ class AccountMailThread(MailThread):
                 if part.get_content_type() == "text/plain":
                     body = part.get_payload(decode=True)
                     break
-                elif part.get_content_type() == "text/html":
+                if part.get_content_type() == "text/html":
                     html = part.get_payload(decode=True)
             if not body:
                 body = html

--- a/d_rats/formbuilder.py
+++ b/d_rats/formbuilder.py
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import ast
 import os
 import glob
@@ -38,7 +35,7 @@ if not '_' in locals():
     _ = gettext.gettext
 
 
-from d_rats import dplatform
+from .dplatform import Platform
 from .miscwidgets import make_choice
 from .formgui import FormDialog, FormFile, xml_escape, FormguiFileException
 
@@ -916,7 +913,7 @@ class FormManagerGUI():
         :param _button: Button clicked, unused
         :type _button: :class:`Gtk.Button`
         '''
-        platform = dplatform.get_platform()
+        platform = Platform.get_platform()
         fname = platform.gui_open_file()
         if not fname:
             return
@@ -944,7 +941,7 @@ class FormManagerGUI():
         (filename, ident) = sel_list.get(sel_iter, self.col_file,
                                          self.col_id)
 
-        platform = dplatform.get_platform()
+        platform = Platform.get_platform()
         fname = platform.gui_save_file(default_name="%s.xml" % ident)
         if fname:
             shutil.copy(filename, fname)
@@ -1015,6 +1012,8 @@ class FormManagerGUI():
         return hbox
 
 
+# pylint wants at least 2 public methods.
+# pylint: disable=too-few-public-methods
 class TestFormbuilderGUI(Gtk.Application):
     '''
     Test application.
@@ -1025,6 +1024,7 @@ class TestFormbuilderGUI(Gtk.Application):
                                  application_id='localhost.d-rats.fbg',
                                  flags=Gio.ApplicationFlags.NON_UNIQUE)
 
+        # pylint: disable=import-outside-toplevel
         from . import config
         self.config = config.DratsConfig(None)
         logging.basicConfig(level=logging.INFO)

--- a/d_rats/formgui.py
+++ b/d_rats/formgui.py
@@ -1,4 +1,3 @@
-#
 '''Form GUI'''
 # pylint wants only 1000 lines per module
 # pylint: disable=too-many-lines
@@ -18,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import base64
 from configparser import NoOptionError
 import logging
@@ -36,7 +32,6 @@ from lxml import etree
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
-# from gi.repository import Gdk
 from gi.repository import GObject
 
 if not '_' in locals():
@@ -49,7 +44,7 @@ MODULE_LOGGER = logging.getLogger("Formgui")
 from .miscwidgets import make_choice, KeyedListWidget
 from .utils import run_or_error
 from .ui.main_common import ask_for_confirmation
-from . import dplatform
+from .dplatform import Platform
 from . import spell
 
 # Not currently used
@@ -1567,7 +1562,7 @@ class FormDialog(FormFile, Gtk.Dialog):
         '''
         self.logger.info("but_save: what is calling this?",
                          stack_info=True)
-        platform = dplatform.get_platform()
+        platform = Platform.get_platform()
         outfile = platform.gui_save_file(default_name="%s.html" % self.ident)
         if not outfile:
             return
@@ -1601,7 +1596,7 @@ class FormDialog(FormFile, Gtk.Dialog):
 
         self.logger.info("button_printable: Exported to temporary file: %s",
                          name)
-        dplatform.get_platform().open_html_file(name)
+        Platform.get_platform().open_html_file(name)
 
     @staticmethod
     def calc_check(buffer, check_widget):
@@ -1745,7 +1740,7 @@ class FormDialog(FormFile, Gtk.Dialog):
             :type _button: :class:`GtkWidget`
             '''
             # pylint: disable=consider-using-with
-            fname = dplatform.get_platform().gui_open_file()
+            fname = Platform.get_platform().gui_open_file()
             if fname:
                 name = os.path.basename(fname)
                 file_handle = open(fname, "rb")
@@ -1788,7 +1783,7 @@ class FormDialog(FormFile, Gtk.Dialog):
             name = self.attachment_box.get_selected()
             if not name:
                 return
-            fname = dplatform.get_platform().gui_save_file(default_name=name)
+            fname = Platform.get_platform().gui_save_file(default_name=name)
             if fname:
                 # pylint: disable=consider-using-with
                 file_handle = open(fname, "wb")
@@ -2144,11 +2139,14 @@ def main():
         logger.info("response: %d = %s", response, act)
         logger.info("info: %s", info)
 
-    form = FormDialog("Form", sys.argv[1], config=config_data)
+    if len(sys.argv) > 1:
+        form = FormDialog("Form", sys.argv[1], config=config_data)
 
-    form.connect("response", form_done, current_info)
-    form.run_dialog()
-    form.destroy()
+        form.connect("response", form_done, current_info)
+        form.run_dialog()
+        form.destroy()
+    else:
+        print("Need a form parameter from the forms directory.")
 
 if __name__ == "__main__":
     main()

--- a/d_rats/gps.py
+++ b/d_rats/gps.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 '''GPS Module.'''
 # pylint wants only 1000 lines
 # pylint: disable=too-many-lines
@@ -20,10 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
-from __future__ import absolute_import
-from __future__ import print_function
-
 import logging
 import re
 import time
@@ -37,7 +32,7 @@ import socket
 from math import pi, cos, acos, sin, atan2
 import serial
 
-from . import dplatform
+from .dplatform import Platform
 
 from . import utils
 
@@ -53,7 +48,7 @@ TEST = "$GPGGA,180718.02,4531.3740,N,12255.4599,W,1,07,1.4," \
 EARTH_RADIUS = 3963.1
 EARTH_UNITS = "mi"
 
-DEGREE = u"\u00b0"
+DEGREE = "\u00b0"
 
 DPRS_TO_APRS = {}
 
@@ -179,7 +174,7 @@ def parse_dms(string):
     :returns: Degrees
     :rtype: float
     '''
-    string = string.replace(u"\u00b0", " ")
+    string = string.replace("\u00b0", " ")
     string = string.replace('"', ' ')
     string = string.replace("'", ' ')
     string = string.replace('  ', ' ')
@@ -673,8 +668,7 @@ class GPSPosition():
                 comment,
                 new_distance,
                 direct)
-        else:
-            return "(" + _("Invalid GPS data") + ")"
+        return "(" + _("Invalid GPS data") + ")"
 
     @staticmethod
     def _nmea_format(val, latitude):
@@ -1000,7 +994,9 @@ class NMEAGPSPosition(GPSPosition):
     def _parse_gpgga(self, string):
         elements = string.split(",", 14)
         if len(elements) < 15:
-            raise GpsGpggaParseError("Unable to split GPGGA" % len(elements))
+            raise GpsGpggaParseError("Unable to split GPGGA, "
+                                     "have %s of 15" %
+                                     len(elements))
 
         time_str = time.strftime("%m%d%y") + elements[1]
         if "." in time_str:
@@ -1093,6 +1089,7 @@ class NMEAGPSPosition(GPSPosition):
         try:
             self._parse_gpgga(string)
         except GpsGpggaException as err:
+            # pylint: disable=import-outside-toplevel
             import traceback
             import sys
             traceback.print_exc(file=sys.stdout)
@@ -1103,6 +1100,7 @@ class NMEAGPSPosition(GPSPosition):
         try:
             self._parse_gprmc(string)
         except GpsGprmcException as err:
+            # pylint: disable=import-outside-toplevel
             import traceback
             import sys
             traceback.print_exc(file=sys.stdout)
@@ -1313,7 +1311,7 @@ class MapImage():
         fhandle.write(self.make_html())
         fhandle.flush()
         fhandle.close()
-        platform = dplatform.get_platform()
+        platform = Platform.get_platform()
         platform.open_html_file(fhandle.name)
 
 
@@ -1597,7 +1595,7 @@ class StaticGPSSource(GPSSource):
         return _("Static position")
 
 
-def parse_GPS(string):
+def parse_gps(string):
     '''
     Parse GPS string.
 

--- a/d_rats/mainapp.py
+++ b/d_rats/mainapp.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 '''mainapp'''
 # pylint wants only 1000 lines
 # pylint: disable=too-many-lines
@@ -19,10 +18,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-from __future__ import absolute_import
-from __future__ import print_function
-
 
 from configparser import NoOptionError
 import logging
@@ -45,7 +40,7 @@ from gi.repository import Gio
 from gi.repository import GObject      # to manage multitasking
 from gi.repository import GLib
 
-from . import dplatform
+from .dplatform import Platform
 
 logging.basicConfig(level=logging.INFO)
 
@@ -54,7 +49,7 @@ MAINAPP_LOGGER = logging.getLogger("Mainapp")
 # This code is assuming that mainapp is only imported in d-rats
 # This needs to be moved to later, but before the first message is written.
 # The also needs to be integrated into the logging module.
-DEBUG_PATH = dplatform.get_platform().config_file("debug.log")
+DEBUG_PATH = Platform.get_platform().config_file("debug.log")
 if sys.platform == "win32" or not os.isatty(0):
     sys.stdout = open(DEBUG_PATH, "w")
     sys.stderr = sys.stdout
@@ -89,7 +84,6 @@ from .emailgw import PeriodicAccountMailThread
 from .emailgw import AccountMailThread
 from .emailgw import validate_incoming
 from .emailgw import EmailGatewayException
-from .dplatform import get_platform
 from .ui import main_events
 from .ui.main_common import prompt_for_station
 
@@ -154,6 +148,7 @@ def ping_file(filename):
     try:
         fhandle = NetFile(filename, "r")
     except IOError as err:
+        # pylint: disable=raise-missing-from
         raise MainappFileOpenError("Unable to open file %s: %s" %
                                    (filename, err))
 
@@ -175,7 +170,7 @@ def ping_exec(command):
     :returns: Output of command
     :rtype: str
     '''
-    pform = get_platform()
+    pform = Platform.get_platform()
     scmd, ocmd = pform.run_sync(command)
     if scmd:
         raise MainappExecError("Failed to run command: %s" % command)
@@ -996,7 +991,7 @@ class MainApp(Gtk.Application):
         locale = locales.get(self.config.get("prefs", "language"), "English")
         self.logger.info("_refresh_lang: Loading locale `%s'", locale)
 
-        localedir = os.path.join(dplatform.get_platform().source_dir(),
+        localedir = os.path.join(Platform.get_platform().sys_data(),
                                  "locale")
         self.logger.info("_refresh_lang: Locale dir is: %s", localedir)
 
@@ -2017,7 +2012,7 @@ class MainApp(Gtk.Application):
         self.logger.info("D-RATS v%s starting at %s on %s",
                          version.DRATS_VERSION,
                          time.asctime(),
-                         dplatform.get_platform())
+                         Platform.get_platform())
 
     def get_position(self):
         '''
@@ -2079,7 +2074,7 @@ class MainApp(Gtk.Application):
     def main(self):
         '''Main.'''
         # Copy default forms before we start
-        distdir = dplatform.get_platform().source_dir()
+        distdir = Platform.get_platform().sys_data()
         userdir = self.config.form_source_dir()
         dist_forms = glob.glob(os.path.join(distdir, "forms", "*.x?l"))
         for form in dist_forms:

--- a/d_rats/map/mapdisplay.py
+++ b/d_rats/map/mapdisplay.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 '''Map Display Unit Test for GTK3'''
 #
 # Copyright 2021-2022 John Malmberg <wb8tyw@gmail.com>
@@ -19,10 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
-
+import argparse
 import logging
 import os
 import gi
@@ -31,7 +27,7 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gio
 from gi.repository import Gtk
 
-from d_rats.dplatform import get_platform
+from d_rats.dplatform import Platform
 from d_rats import config
 from d_rats import map_sources
 
@@ -63,7 +59,7 @@ class MapDisplay(Gtk.Application):
 
         self.config = config.DratsConfig(None)
         self.cmd_args = cmd_args
-        get_platform(cmd_args.config)
+        Platform.get_platform(cmd_args.config)
 
         maptype = self.config.get("settings", "maptype")
         if maptype == "cycle":
@@ -152,8 +148,6 @@ class MapDisplay(Gtk.Application):
 def main():
     '''Main function for unit testing.'''
 
-    import argparse
-
     gettext.install("D-RATS")
     lang = gettext.translation("D-RATS",
                                localedir="locale",
@@ -193,7 +187,7 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description=_('MAP DISPLAY TEST'))
     parser.add_argument('-c', '--config',
-                        default=get_platform().config_dir(),
+                        default=Platform.get_platform().config_dir(),
                         help=_("USE ALTERNATE CONFIGURATION DIRECTORY"))
 
     # While loglevel actually returns an int, it needs to be set to the

--- a/d_rats/map/mapwindow.py
+++ b/d_rats/map/mapwindow.py
@@ -36,7 +36,7 @@ from gi.repository import Gdk
 from gi.repository import GLib
 from gi.repository import GObject
 
-from .. import dplatform
+from ..dplatform import Platform
 from .. import inputdialog
 from .. import map_sources
 from .. import miscwidgets
@@ -762,7 +762,7 @@ class MapWindow(Gtk.ApplicationWindow):
         :returns: False to prevent timer retriggering
         :rtype: bool
         '''
-        platform = dplatform.get_platform()
+        platform = Platform.get_platform()
 
         file_handle = tempfile.NamedTemporaryFile()
         fname = file_handle.name
@@ -900,7 +900,7 @@ class MapWindow(Gtk.ApplicationWindow):
         :param bounds: Bounds to save, Default None
         :type bounds: tuple[int, int, int, int]
         '''
-        platform = dplatform.get_platform()
+        platform = Platform.get_platform()
         fname = platform.gui_save_file(default_name="map_%s.png" % \
                                        time.strftime("%m%d%Y%_H%M%S"))
         if not fname:

--- a/d_rats/map_sources.py
+++ b/d_rats/map_sources.py
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import logging
 import re
 import time
@@ -27,9 +24,9 @@ import threading
 import os
 import urllib
 from glob import glob
-from lxml import etree
 from configparser import NoSectionError
 from configparser import NoOptionError
+from lxml import etree
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -37,7 +34,7 @@ from gi.repository import GLib
 from gi.repository import GObject
 
 from . import utils
-from . import dplatform
+from .dplatform import Platform
 
 
 class MapSourcesException(Exception):
@@ -85,6 +82,7 @@ class MapPoint(GObject.GObject):
 
     def __init__(self):
         GObject.GObject.__init__(self)
+        # pylint: disable=unused-private-member
         self.__latitude = 0.0
         self.__longitude = 0.0
         self.__altitude = 0.0
@@ -137,15 +135,18 @@ class MapPoint(GObject.GObject):
         # Probably should raise an exception
         return None
 
+    # pylint: disable=arguments-differ
     def __repr__(self):
         msg = "%s@%.4f,%.4f" % (self.get_name(),
                                 self.get_latitude(),
                                 self.get_longitude())
         return msg
 
+    # pylint: disable=arguments-differ
     def __str__(self):
         return self.get_name()
 
+    # pylint: disable=arguments-differ
     def __eq__(self, point):
         return self.get_name() == point.get_name()
 
@@ -299,7 +300,7 @@ class MapUSGSRiver(MapPointThreaded):
               "?format=mapper&sites=%s&siteOutput=expanded&siteStatus=all" % \
               self.__site
 
-        platform = dplatform.get_platform()
+        platform = Platform.get_platform()
         try:
             filter_filename, _headers = platform.retrieve_url(url)
             content = open(filter_filename).read()
@@ -328,7 +329,7 @@ class MapUSGSRiver(MapPointThreaded):
             "http://waterdata.usgs.gov/nwis/uv?format=rdb&period=1&site_no=%s" \
             % self.__site
 
-        platform = dplatform.get_platform()
+        platform = Platform.get_platform()
         try:
             file_name, _headers = platform.retrieve_url(url)
             line = open(file_name).readlines()[-1]
@@ -368,7 +369,7 @@ class MapNBDCBuoy(MapPointThreaded):
 
     def do_update(self):
         '''Do Update.'''
-        platform = dplatform.get_platform()
+        platform = Platform.get_platform()
         try:
             fname, _headers = platform.retrieve_url(self.__url)
             content = open(fname).read()
@@ -594,6 +595,7 @@ class MapFileSource(MapSource):
         except (PermissionError, FileNotFoundError) as err:
             msg = "Failed to open %s: %s" % (filename, err)
             self.logger.info("Failed to open %s: %s")
+            # pylint: disable=raise-missing-from
             raise MapSourceFailedToConnect(msg)
 
         lines = input_handle.readlines()
@@ -653,6 +655,7 @@ class MapFileSource(MapSource):
             ident, icon, lat, lon, alt, comment, show = line.split(",", 6)
         except ValueError:
             self.logger.info("parse_line failed (%s)")
+            # pylint: disable=raise-missing-from
             raise MapSourcePointError
 
         if alt:
@@ -844,6 +847,7 @@ class MapNBDCBuoySource(MapSource):
             logger.info("_open_source_by_name: No option %s.label",
                         name, exc_info=True)
             _name = name
+        # pylint: disable=unnecessary-comprehension, consider-using-generator
         sites = tuple([x for x in _sites])
 
         return MapNBDCBuoySource(_name, "NBDC Buoys", *sites)

--- a/d_rats/miscwidgets.py
+++ b/d_rats/miscwidgets.py
@@ -1,4 +1,3 @@
-#
 '''Misc Widgets.'''
 # pylint wants only 1000 lines per module.
 # pylint: disable=too-many-lines
@@ -18,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import logging
 import os
 
@@ -32,7 +28,7 @@ from gi.repository import GdkPixbuf
 from gi.repository import GObject
 from gi.repository import Pango
 
-from . import dplatform
+from .dplatform import Platform
 from .dratsexception import LatLonEntryParseDMSError
 from .dratsexception import LatLonEntryValueError
 
@@ -1278,9 +1274,9 @@ class FilenameBox(Gtk.Box):
             start = None
 
         if directory:
-            fname = dplatform.get_platform().gui_select_dir(start)
+            fname = Platform.get_platform().gui_select_dir(start)
         else:
-            fname = dplatform.get_platform().gui_save_file(start)
+            fname = Platform.get_platform().gui_save_file(start)
         if fname:
             self.filename.set_text(fname)
 

--- a/d_rats/qst.py
+++ b/d_rats/qst.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # pylint: disable=too-many-lines
 '''QST.'''
 #
@@ -17,9 +16,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-from __future__ import absolute_import
-from __future__ import print_function
 
 import datetime
 import json
@@ -41,27 +37,25 @@ if not '_' in locals():
 from .miscwidgets import make_choice
 from . import miscwidgets
 
-from . import dplatform
+from .dplatform import Platform
 from . import inputdialog
 from . import cap
-# from . import wu
 from . import gps
 from .utils import combo_select, get_icon
 
-# pylint: disable=invalid-name
-module_logger = logging.getLogger("QST")
+QST_LOGGER = logging.getLogger("QST")
 
 try:
     import feedparser
     HAVE_FEEDPARSER = True
 except ImportError:
-    module_logger.info("FeedParser not available")
+    QST_LOGGER.info("FeedParser not available")
     HAVE_FEEDPARSER = False
 
 try:
     from hashlib import md5
 except ImportError:
-    module_logger.info("Installing hashlib replacement hack")
+    QST_LOGGER.info("Installing hashlib replacement hack")
     from .utils import ExternalHash as md5
 
 
@@ -201,7 +195,7 @@ class QSTExec(QSTText):
         :rtype: str
         '''
         size_limit = self.config.getint("settings", "qst_size_limit")
-        pform = dplatform.get_platform()
+        pform = Platform.get_platform()
         status, output = pform.run_sync(self.text)
         if status:
             self.logger.info("Command failed with status %i", status)

--- a/d_rats/sessions/chat.py
+++ b/d_rats/sessions/chat.py
@@ -16,9 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import logging
 import random
 import time
@@ -28,7 +25,11 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import GLib
 from gi.repository import GObject
 
-from d_rats import signals, dplatform, gps, utils, station_status
+from d_rats import gps
+from d_rats import signals
+from d_rats import station_status
+from d_rats import utils
+from d_rats.dplatform import Platform
 from d_rats.version import DRATS_VERSION
 from d_rats.sessions import base, stateless
 from d_rats.ddt2 import DDT2EncodedFrame, DDT2RawData
@@ -103,7 +104,7 @@ class ChatSession(stateless.StatelessSession, GObject.GObject):
         :returns: A standard ping response text with d-rats version
         :rtype: str
         '''
-        pform = dplatform.get_platform()
+        pform = Platform.get_platform()
         return _("Running") + " D-RATS %s (%s)" % (DRATS_VERSION,
                                                    pform.os_version_string())
 
@@ -130,7 +131,7 @@ class ChatSession(stateless.StatelessSession, GObject.GObject):
         self.logger.debug("incoming_data: Got chat frame: %s", frame)
         frame_data = frame.data.decode('utf-8', 'replace')
         if frame.type == self.T_DEF:
-            fix = gps.parse_GPS(frame_data)
+            fix = gps.parse_gps(frame_data)
             if fix and fix.valid:
                 self._incoming_gps(fix)
             else:

--- a/d_rats/utils.py
+++ b/d_rats/utils.py
@@ -1,4 +1,3 @@
-#
 '''utility Methods.'''
 # Copyright 2008 Dan Smith <dsmith@danplanet.com>
 # Copyright 2021-2022 John Malmberg <wb8tyw@gmail.com> python3 gtk3 update
@@ -16,9 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import absolute_import
-from __future__ import print_function
-
 import logging
 from io import FileIO
 
@@ -27,7 +23,13 @@ import tempfile
 
 import urllib.request
 
-from . import dplatform
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+from gi.repository import Gdk
+from gi.repository import GdkPixbuf
+
+from .dplatform import Platform
 
 # This makes pylance happy with out overriding settings
 # from the invoker of the class
@@ -45,10 +47,6 @@ def open_icon_map(iconfn):
     :returns: Icon Map or None
     :rtype: :class:`GdkPixbuf.Pixbuf`
     '''
-    import gi
-    gi.require_version("Gdk", "3.0")
-    from gi.repository import GdkPixbuf
-
     logger = logging.getLogger("Utils.open_icon_map")
     if not os.path.exists(iconfn):
         logger.info("Icon file %s not found", iconfn)
@@ -71,9 +69,9 @@ def init_icon_maps():
     global ICON_MAPS
 
     ICON_MAPS = {
-        "/" : open_icon_map(os.path.join(dplatform.get_platform().source_dir(),
+        "/" : open_icon_map(os.path.join(Platform.get_platform().sys_data(),
                                          "images", "aprs_pri.png")),
-        "\\": open_icon_map(os.path.join(dplatform.get_platform().source_dir(),
+        "\\": open_icon_map(os.path.join(Platform.get_platform().sys_data(),
                                          "images", "aprs_sec.png")),
         }
 
@@ -220,9 +218,6 @@ def run_gtk_locked(function):
     :returns: function result or raise error
     :rtype: any
     '''
-    import gi
-    gi.require_version("Gdk", "3.0")
-    from gi.repository import Gdk
 
     def runner(*args, **kwargs):
         Gdk.threads_enter()
@@ -248,9 +243,7 @@ def run_or_error(function):
     :type function: function
     :returns: Function result or raise error
     '''
-    # import gi
-    # gi.require_version("Gtk", "3.0")
-    # from gi.repository import Gtk
+    # pylint: disable=import-outside-toplevel
     from d_rats.ui import main_common
 
     def runner(*args, **kwargs):
@@ -268,6 +261,7 @@ def run_or_error(function):
 # possibly deprecated to be replaced by logging module.
 def print_stack():
     '''Print Stack'''
+    # pylint: disable=import-outside-toplevel
     import traceback
     import sys
     traceback.print_stack(file=sys.stdout)
@@ -287,10 +281,6 @@ def get_sub_image(iconmap, h_offset, v_offset, size=20):
     :returns: icon extracted from icon map
     :rtype: :class:`GdkPixbuf.Pixbuf`
     '''
-    import gi
-    gi.require_version("Gdk", "3.0")
-    from gi.repository import GdkPixbuf
-
     # Account for division lines (1px per icon)
     x_coord = (h_offset * size) + h_offset + 1
     y_coord = (v_offset * size) + v_offset + 1
@@ -389,12 +379,11 @@ class NetFile(FileIO):
                 self.logger.info("init: Retrieving %s -> %s", uri, self.__fn)
                 urllib.request.urlretrieve(uri, self.__fn)
                 break
-
-        super(NetFile, self).__init__(self, self.__fn, mode, buffering)
+        super().__init__(self, self.__fn, mode, buffering)
 
     def close(self):
         '''close'''
-        super(NetFile, self).close(self)
+        super().close(self)
 
         if self.is_temp:
             os.remove(self.__fn)
@@ -413,6 +402,7 @@ class ExternalHash():
         :param val: value to write
         :type val: bytes
         '''
+        # pylint: disable=import-outside-toplevel
         from subprocess import Popen, PIPE
         proc = Popen("md5sum", shell=True,
                      stdin=PIPE, stdout=PIPE, close_fds=True)
@@ -455,6 +445,7 @@ def combo_select(box, value):
 
 def log_exception():
     '''Log Exception.'''
+    # pylint: disable=import-outside-toplevel
     import traceback
     import sys
 
@@ -478,11 +469,6 @@ def set_entry_hint(entry, hint, default_focused=False):
     :param default_focus: Optional make default focused
     :type default_focus: bool
     '''
-    import gi
-    gi.require_version("Gtk", "3.0")
-    from gi.repository import Gtk
-    from gi.repository import Gdk
-
     def focus(entry, _event, direction):
         if direction == "out" and not entry.get_text():
             entry.set_text(hint)
@@ -536,9 +522,6 @@ def make_error_dialog(msg, stack, buttons, msg_type, extra):
     :returns: Result of running error dialog
     :rtype: :class:`Gtk.ResponseType`
     '''
-    import gi
-    gi.require_version("Gtk", "3.0")
-    from gi.repository import Gtk
     dialog = Gtk.MessageDialog(buttons=buttons, type=msg_type)
 
     if extra:

--- a/d_rats/wl2k.py
+++ b/d_rats/wl2k.py
@@ -22,7 +22,7 @@ from gi.repository import GLib
 from gi.repository import GObject
 
 from d_rats import version
-from d_rats import dplatform
+from d_rats.dplatform import Platform
 from d_rats import formgui
 from d_rats import signals
 from d_rats.crc_checksum import calc_checksum
@@ -130,7 +130,7 @@ def run_lzhuf(cmd, data):
     :type data: bytes
     '''
     logger = logging.getLogger("run_lzhuf")
-    platform = dplatform.get_platform()
+    platform = Platform.get_platform()
 
     cwd = tempfile.mkdtemp()
 
@@ -150,7 +150,7 @@ def run_lzhuf(cmd, data):
     else:
         lzhuf = "lzhuf"
 
-    lzhuf_path = os.path.abspath(os.path.join(platform.source_dir(),
+    lzhuf_path = os.path.abspath(os.path.join(platform.sys_data(),
                                               "libexec", lzhuf))
     shutil.copy(os.path.abspath(lzhuf_path), cwd)
     run = [lzhuf_path, cmd, "input", "output"]

--- a/tests/pre-commit_d/pylint_check.sh
+++ b/tests/pre-commit_d/pylint_check.sh
@@ -2,6 +2,9 @@
 
 set -ue
 
+# Needed for some platforms
+export NO_AT_BRIDGE=1
+
 # Default list of files to lint
 : "${CHANGED_FILES:=}"
 if [ -z "$CHANGED_FILES" ]; then


### PR DESCRIPTION
test/pre-commit_d/pylint_check.sh:
  Suppress dbind-warning on some platforms.

d_rats/dplatform:
  Rename source_dir to sys_data.
  Detect when running from a git checkout when selecting
  what data to use.
  Add method for finding an executable to run.

d_rats/config.py:
d_rats/emailgw.py:
d_rats/formbuilder.py:
d_rats/formgui.py:
d_rats/gps.py:
d_rats/mainapp.py:
d_rats/map_sources.py:
d_rats/miscwidgets.py:
d_rats/qst.py:
d_rats/utils.py:
d_rats/wl2k.py:
d_rats/map/mapdisplay.py:
d_rats/map/mapwindow.py:
d_rats/sessions/chat.py:
  Remove useless shebang and __future__ imports if present.
  Use refactored dplatform module.
  Suppress any new pylint diagnostics.

d-rats.py:
d-rats_repeater.py:
  Use refactored dplatform module.
  Suppress new pylint diagnostics.