### PR TITLE
Use lzhuf from its own project

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,7 +11,6 @@ include d-rats.py
 include d-rats_repeater.py
 include share/d-rats2.xpm
 include d-rats2.ico
-include libexec/lzhuf
 include MANIFEST.in
 include COPYING
 include changelog.gz

--- a/README.md
+++ b/README.md
@@ -82,21 +82,30 @@ things.
 
 ## Supported systems
 
-Currently this experimental fork is only being tested by John Malmberg
-on Anti-X linux, which can run both the experimental version and the stable version and Msys2 mingw64 on Microsoft Windows which can only run the Python 3 version.
+This should run on any system with currently supported Python 3 and a GTK 3
+library.
 
-Anti-X Linux is a Debian based distribution that will run on older systems
-with limited memory.
+There may be commercial Pythons that are free for non-commercial use that
+may come with a GTK+ 3 library.  John Malmberg will not be testing any
+product that requires a paid license for commercial use.  If someone wants
+to contribute instructions on how to install on a Commercial Python to
+<https://github.com/ham-radio-software/D-Rats/wiki> that will help others.
+
+### Microsoft Windows
+
+This generally requires installing the msys2 package from
+<https://www.msys2.org/wiki/MSYS2-installation/>, which is what is currently
+used for testing.
+
+Other alternatives Windows Subsystem for Linux with a Linux installed or
+Cygwin <https://www.cygwin.com/install.html>.  At the present time those
+are not being tested.
+
+### Linux and MAC OS-X
+
+Current testing is primarily done with Anti-X Linux which is a Debian based distribution that will run on older systems with limited memory.
 
 This version requires Python 3.7+ and GTK-3.
-
-For now support or the pre-built executables has been dropped.
-You will need to install a Python 3 interpreter.
-
-John Malmberg will not be installing or testing any Python interpreter
-that requires a paid license for commercial work, even if that license allows
-free non-commercial use.  Some Python distributions for Desktop platforms
-have this restriction.
 
 ---
 
@@ -125,6 +134,22 @@ Quick update by John Malmberg
 
 See also <https://github.com/ham-radio-software/D-Rats/wiki>
 
+You must have a compatible python3 and GTK 3 installed on the system to run
+D-Rats as listed above.
+
+For msys2, the script msys2_packages.sh will hopefully install all the
+needed packages after you have installed msys2.  The "dev" parameter
+is passed to install extra images needed for development, or installing
+ directly from a git archive.
+
+If the script is updating certain packages, it may need to have the msys2
+windows shutdown after running, and then need to be re-run to complete the
+install.
+
+Repeat running the script until it no longer requests a msys2 restart.
+Normally an msys2 restart or install should not require a reboot of
+Microsoft Windows.
+
 The installation steps are quite easy (assuming one has all the needed Python
 libs installed):
 
@@ -152,23 +177,11 @@ aspell-it yamllint
 Anti-x 22 Can not run the older D-rats on Python 2, so only the Python 3
 packages can be installed.
 
-aspell aspell-en bandit(future) gedit python3 pylint pylint3 glade
-python3-gi python3-serial python3-lxml python3-simplejson
-python3-feedparser python3-flask python3-gevent python3-greenlet
-python3-ipykernel python3-gi-cairo python3-geopy python3-pil
-python3-pip shellcheck codespell libxml2-utils aspell-it yamllint
-
-For msys2, the script msys2_packages.sh will hopefully install all the
-needed packages.  The "dev" parameter is passed to install extra images
-needed for development, or installing directly from a git archive.
-
-If the script is updating certain packages, it may need to have the msys2
-windows shutdown after running, and then need to be re-run to complete the
-install.
-
-Repeat running the script until it no longer requests a msys2 restart.
-Normally an msys2 restart or install should not require a reboot of
-Microsoft Windows.
+aspell aspell-en aspell-it bandit(future) codespell gedit glade libxml2-utils
+pylint pylint3 python3 python3-feedparser python3-flask python3-geopy
+python3-gevent python3-gi python3-gi-cairo python3-greenlet python3-ipykernel
+python3-lxml python3-pil python3-pip python3-serial python3-simplejson
+python3-sphinx python3_venv shellcheck yamllint
 
 Other Python interpreters should be similar.  If the Python distribution does
 not supply all of the packages, then PIP can be used to supply the missing
@@ -178,6 +191,25 @@ environment.
 See: <https://github.com/ham-radio-software/D-Rats/wiki/101.010-Running-D-Rats-in-a-Python-virtual-environment-and-PIP>
 
 And read the rest of this document for more tips.
+
+If you want to connect to WinLInk, you will need to install lzhuf.
+
+The lzhuf source code is in its own repository and can easily be built on
+most Linux or OS-X based systems.
+<https://github.com/ham-radio-software/lzhuf>
+
+If you locally build lzhuf on a Linux or Mac OS system, the lzhuf binary
+built should be placed in /usr/local/bin for D-Rats to use it.
+
+For some platforms, prebuilt lzhuf binaries may be available for download
+from the files section of <https://groups.io/g/d-rats> group.
+
+You must be a member of the <https://groups.io/g/d-rats> group and logged
+in to the web page in order for thed ownload link of
+<https://groups.io/g/d-rats/files/D-Rats>.
+
+Currently prebuilt MSI packages are available for Microsoft Windows,
+and Debian packages for some Debian and Ubuntu releases.
 
 ### Running directly from the D-rats source
 
@@ -190,9 +222,8 @@ archive of any commit or pull request.
 Before running D-Rats there are two optional tasks if you want everything
 to work.
 
-If you want Winlink support to work, you need to build the lzhuf binary.
-
-- make -C libexec
+If you want Winlink support to work, you need to download or build the lzhuf
+binary,  which is now in its own repository as noted above.
 
 If you want the internationalization to work, and especially if you want
 to add more languages you have to build the message catalogs.

--- a/d_rats/lzhuf.py
+++ b/d_rats/lzhuf.py
@@ -1,0 +1,152 @@
+'''lzhuf module.'''
+#
+# Copyright 2008 Dan Smith <dsmith@danplanet.com>
+# Copyright 2021-2022 John. E. Malmberg - Python3 Conversion
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+import tempfile
+import struct
+import subprocess
+import sys
+
+from d_rats import crc_checksum
+from d_rats.dplatform import Platform
+
+
+class Lzhuf():
+    '''Lzhuf.'''
+
+    logger = logging.getLogger("Lzhuf")
+    lzhuf_path = None
+
+    @classmethod
+    def _set_lzhuf_path(cls):
+        if cls.lzhuf_path:
+            return
+        cls.lzhuf_path = Platform.get_exe_path('lzhuf')
+
+    @classmethod
+    @property
+    def have_lzhuf(cls):
+        '''
+        Have lzhuf?
+
+        Do we have the lzhuf executable?
+        :returns: True if we have lzhuf
+        :rtype: bool
+        '''
+        cls._set_lzhuf_path()
+        if cls.lzhuf_path:
+            return True
+        return False
+
+    @classmethod
+    def _run(cls, cmd, data):
+        '''
+        Run lzhuf internal.
+
+        :param cmd: lzhuf command
+        :type cmd: str
+        :param data: Data to process
+        :type data: bytes
+        :returns: Processed data
+        :rtype: bytes
+        '''
+        cls._set_lzhuf_path()
+        if not cls.lzhuf_path:
+            cls.logger.info("lzhuf binary not found")
+            return None
+        tmp_dir = tempfile.mkdtemp()
+
+        with open(os.path.join(tmp_dir, "input"), "wb") as file_handle:
+            file_handle.write(data)
+
+        kwargs = {}
+        if sys.platform == 'win32':
+            child = subprocess.STARTUPINFO()
+            child.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            child.wShowWindow = subprocess.SW_HIDE
+            kwargs["startupinfo"] = child
+
+        run = [cls.lzhuf_path, cmd, "input", "output"]
+
+        cls.logger.info("Running %s in %s", run, tmp_dir)
+
+        ret = subprocess.call(run, cwd=tmp_dir, **kwargs)
+        cls.logger.info("LZHUF returned %s", ret)
+        if ret:
+            return None
+
+        with open(os.path.join(tmp_dir, "output"), "rb") as file_handle:
+            data = file_handle.read()
+
+        return data
+
+    @classmethod
+    def decode(cls, data):
+        '''
+        Run LZHUF Decode.
+
+        :param data: Encoded data
+        :type data: bytes
+        :returns: Uncompressed data
+        :rtype: bytes
+        '''
+        return cls._run("d", data[2:])
+
+    @classmethod
+    def encode(cls, data):
+        '''
+        Run LZHUF Encode.
+
+        :param data: Unencoded data
+        :type data: bytes
+        :returns: Compressed data
+        :rtype: bytes
+        '''
+        lzh = cls._run("e", data)
+        if lzh:
+            lzh = struct.pack("<H", crc_checksum.calc_checksum(lzh)) + lzh
+        else:
+            cls.logger.info('encode: lzhuf returned no data')
+        return lzh
+
+
+def main():
+    '''Unit Test.'''
+
+    logging.basicConfig(format="%(asctime)s:%(levelname)s:%(name)s:%(message)s",
+                        datefmt="%m/%d/%Y %H:%M:%S",
+                        level=logging.INFO)
+
+    logger = logging.getLogger("lzhuf_test")
+    logger.info("Starting test")
+    in_data = b'uncompressed'
+    encoded = Lzhuf.encode(in_data)
+    if encoded:
+        decoded = Lzhuf.decode(encoded)
+        print("in_data=", in_data)
+        print("decoded=", decoded)
+        if decoded != in_data:
+            logger.info("Sanity test failed!")
+        else:
+            logger.info("Sanity test passed!")
+    else:
+        logger.info("Sanity test lzhuf not found!")
+
+if __name__ == "__main__":
+    main()

--- a/d_rats/msgrouting.py
+++ b/d_rats/msgrouting.py
@@ -658,6 +658,10 @@ class MessageRouter(GObject.GObject):
         :returns: True
         :rtype bool
         '''
+        if not wl2k.WinLinkMessage.have_winlink:
+            self.logger.info('_route_via_station: '
+                             'Winlink lzhuf compression not installed.')
+            return False
         # Temporary to get diagnostics about wl2k failures.
         self.logger.info('_route_via_station: '
                          'src %s %s dst %s %s msgfn %s %s',

--- a/docs/source/d_rats.rst
+++ b/docs/source/d_rats.rst
@@ -69,6 +69,14 @@ d\_rats.config\_tips module
     :undoc-members:
     :show-inheritance:
 
+d\_rats.crc\_checksum module
+---------------------------
+
+.. automodule:: d_rats.crc_checksum
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 d\_rats.ddt2 module
 -------------------
 
@@ -153,6 +161,14 @@ d\_rats.inputdialog module
 --------------------------
 
 .. automodule:: d_rats.inputdialog
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+d\_rats.lzhuf module
+----------------------
+
+.. automodule:: d_rats.lzhuf
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Now that lzhuf has been moved to its own project D-Rats just needs to be able to find it and properly diagnose if it is missing.

d_rats/lzhuf: (New Module)
  Python wrapper to lzhuf program.

Manifest.in:
  Remove lzhuf.

README.md:
  Updated for the move of lzhuf into its own package.

d_rats/msgrouting.py:
  Do not try to route winlink messages if lzhuf is not present.

d_rats/wl2k.py:
  Refactor to use new lzhuf class.

docs/source/d_rats.rst:
  Documentation update for lzhuf and crc_checksum