### PR TITLE
Do not hardcode default applications

### DIFF
--- a/changes/129.bugfix
+++ b/changes/129.bugfix
@@ -1,0 +1,1 @@
+User's default html and text viewer applications will now be used.

--- a/d_rats/dplatform_generic.py
+++ b/d_rats/dplatform_generic.py
@@ -44,6 +44,7 @@ import urllib.error
 import gi  # type: ignore # Needed for pylance on Microsoft Windows
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk # type: ignore
+from gi.repository import Gio # type: ignore
 
 
 if '_' not in locals():
@@ -233,33 +234,31 @@ class PlatformGeneric():
         return os.path.join(self.config_dir(),
                             self.filter_filename(filename))
 
-    def open_text_file(self, _path):
+    @staticmethod
+    def open_text_file(path):
         '''
         Open Text File.
 
-        :param _path: Path to file
+        :param path: Path to file
         :type _path: str
-        :raises: :class:`NotImplementedError`
         '''
-        # This is wrong.
-        # GTK should have a built in cross platform method to open
-        # text file, and that should be called instead of this
-        # method to open the file in a safe (read-only/no-macros) manor.
-        raise NotImplementedError("The base class can't do that")
+        content = Gio.content_type_from_mime_type('text/plain')
+        appinfo = Gio.app_info_get_default_for_type(content, False)
+        gio_path = Gio.File.parse_name(path)
+        appinfo.launch([gio_path], None)
 
-    def open_html_file(self, _path):
+    @staticmethod
+    def open_html_file(path):
         '''
         Open HTML File
 
-        :param _path: Path to file
-        :type _path: str
-        :raises: :class:`NotImplementedError`
+        :param path: Path to file
+        :type path: str
         '''
-        # This is wrong.
-        # GTK Should have a built in cross platform method to open
-        # a web browser to an HTML or JPG file that should be called
-        # instead of this method.
-        raise NotImplementedError("The base class can't do that")
+        content = Gio.content_type_from_mime_type('text/html')
+        appinfo = Gio.app_info_get_default_for_type(content, False)
+        gio_path = Gio.File.parse_name(path)
+        appinfo.launch([gio_path], None)
 
     @staticmethod
     def list_serial_ports():

--- a/d_rats/dplatform_macos.py
+++ b/d_rats/dplatform_macos.py
@@ -47,25 +47,6 @@ class MacOSXPlatform(UnixPlatform):
 
         UnixPlatform.__init__(self, basepath)
 
-    def open_html_file(self, path):
-        '''
-        Open HTML File.
-
-        :param path: file to open
-        :type path: str
-        '''
-        self._unix_doublefork_run("open", path)
-
-    def open_text_file(self, path):
-        '''
-        Open Text File for edit.
-
-        :param path: Path to textfile
-        :type path: str
-        '''
-        macos_textedit = "/Applications/TextEdit.app/Contents/MacOS/TextEdit"
-        self._unix_doublefork_run(macos_textedit, path)
-
     def list_serial_ports(self):
         '''
         List Serial Ports.

--- a/d_rats/dplatform_unix.py
+++ b/d_rats/dplatform_unix.py
@@ -21,7 +21,6 @@ import logging
 import glob
 import os
 import subprocess
-import sys
 
 from .dplatform_generic import PlatformGeneric
 
@@ -78,49 +77,6 @@ class UnixPlatform(PlatformGeneric):
         :rtype: str
         '''
         return filename.replace("/", "")
-
-    def _unix_doublefork_run(self, *args):
-        pid1 = os.fork()
-        if pid1 == 0:
-            pid2 = os.fork()
-            if pid2 == 0:
-                self.logger.info("Exec'ing %s", str(args))
-                os.execlp(args[0], *args)
-            else:
-                sys.exit(0)
-        else:
-            os.waitpid(pid1, 0)
-            self.logger.info("Exec child exited")
-
-    def open_text_file(self, path):
-        '''
-        Open Text File for editing.
-
-        :param path: Path to text file
-        :type path: str
-        '''
-        # pylint: disable=fixme
-        # todo find and replace calls with GTK function.
-        self.logger.info("open_text_file: received order"
-                         " to open in gedit %s s", path)
-        self.logger.info("If after this message your linux box crashes, "
-                         "please install gedit")
-        self._unix_doublefork_run("gedit", path)
-
-    def open_html_file(self, path):
-        '''
-        Open HTML file in Firefox.
-
-        :param path: Path of file to open
-        :type path: str
-        '''
-        # pylint: disable=fixme
-        # todo find and replace calls with GTK function.
-        self.logger.info("open_html_file:"
-                         " received order to open in firefox %s", path)
-        self.logger.info("If after this message your linux box crashes, "
-                         "please install firefox")
-        self._unix_doublefork_run("firefox", path)
 
     def list_serial_ports(self):
         '''

--- a/d_rats/dplatform_win32.py
+++ b/d_rats/dplatform_win32.py
@@ -19,7 +19,6 @@
 
 import logging
 import os
-import subprocess
 
 # There has been some problems with various Windows Python
 # implementations in the past.  Having these modules may make
@@ -118,24 +117,6 @@ class Win32Platform(PlatformGeneric):
             filename = filename.replace(char, "")
 
         return filename
-
-    def open_text_file(self, path):
-        '''
-        Open Text File for editing.
-
-        :param path: path of file to open
-        :type path: str
-        '''
-        subprocess.Popen(["notepad", path])
-
-    def open_html_file(self, path):
-        '''
-        Open Html File in explorer.
-
-        :param path: Path to file
-        :type path: str
-        '''
-        subprocess.Popen(["explorer", path])
 
     def list_serial_ports(self):
         '''


### PR DESCRIPTION
First pass, use the operating system designated default applications. In the future it would be nice to have a configuration dialog to allow the user to select from applications known to their desktop.

changes/129:
  Documentation to for future NEWS.rst.

d_rats/dplatform_generic.py:
  Add platform independent text and html file viewer launching.

d_rats/dplatform_macos.py:
d_rats/dplatform_unix.py:
d_rats/dplatform_win32.py:
  Remove platform specific code that could be referencing programs
  that may not be installed.