### PR TITLE
Fix filename selection Dialog

### DIFF
--- a/d_rats/config.py
+++ b/d_rats/config.py
@@ -922,7 +922,8 @@ class DratsConfigWidget(Gtk.Box):
             platform_info = Platform.get_platform()
             platform_info.play_sound(self.value)
 
-        fname_box = FilenameBox(find_dir=False, save=False)
+        fname_box = FilenameBox(find_dir=False, save=False,
+                                mime_types=['audio/x-wav'])
         fname_box.set_filename(self.value)
         fname_box.connect("filename-changed", filename_changed)
         fname_box.show()

--- a/d_rats/config.py
+++ b/d_rats/config.py
@@ -37,6 +37,7 @@ if not '_' in locals():
     import gettext
     _ = gettext.gettext
 
+from .filenamebox import FilenameBox
 from . import utils
 from . import miscwidgets
 from . import inputdialog
@@ -602,7 +603,7 @@ class DratsConfigWidget(Gtk.Box):
             self.child_widget.set_value(float(self.value))
         elif isinstance(self.child_widget, Gtk.CheckButton):
             self.child_widget.set_active(self.value.upper() == "TRUE")
-        elif isinstance(self.child_widget, miscwidgets.FilenameBox):
+        elif isinstance(self.child_widget, FilenameBox):
             self.child_widget.set_filename(self.value)
         else:
             self.logger.info("AAACK: I don't know how to do a %s",
@@ -887,11 +888,11 @@ class DratsConfigWidget(Gtk.Box):
             FilenameBox filename-changed box.
 
             :param box: FilenameBox widget
-            :type box: :class:`miscwidgets.FilenameBox`
+            :type box: :class:`filenamebox.FilenameBox`
             '''
             self.value = box.get_filename()
 
-        fname_box = miscwidgets.FilenameBox(find_dir=True)
+        fname_box = FilenameBox(find_dir=True)
         fname_box.set_filename(self.value)
         fname_box.connect("filename-changed", filename_changed)
         fname_box.show()
@@ -906,7 +907,7 @@ class DratsConfigWidget(Gtk.Box):
             FilenameBox filename-changed box.
 
             :param box: FilenameBox widget
-            :type box: :class:`miscwidgets.FilenameBox`
+            :type box: :class:`filenamebox.FilenameBox`
             '''
             self.value = box.get_filename()
 
@@ -921,7 +922,7 @@ class DratsConfigWidget(Gtk.Box):
             platform_info = Platform.get_platform()
             platform_info.play_sound(self.value)
 
-        fname_box = miscwidgets.FilenameBox(find_dir=False)
+        fname_box = FilenameBox(find_dir=False, save=False)
         fname_box.set_filename(self.value)
         fname_box.connect("filename-changed", filename_changed)
         fname_box.show()

--- a/d_rats/dplatform.py
+++ b/d_rats/dplatform.py
@@ -1,4 +1,10 @@
-'''D-Rats Platform.'''
+'''
+D-Rats Platform.
+
+The Plaform class is intended to be a Singleton class.
+
+The specific platform subclass is duck typed as the class to be used.
+'''
 #
 # Copyright 2009 Dan Smith <dsmith@danplanet.com>
 # review 2015 Maurizio Andreotti  <iz2lxi@yahoo.it>
@@ -101,7 +107,10 @@ def do_test():
 
         pform.open_text_file("d-rats.py")
 
-        logger.info("Open file: %s", pform.gui_open_file())
+        test_file = pform.gui_open_file(mime_types=['audio/x-wav'])
+        logger.info("Open file: %s", test_file)
+        if test_file and test_file.endswith('.wav'):
+            pform.play_sound(soundfile=test_file)
         logger.info("Save file: %s",
                     pform.gui_save_file(default_name="Foo.txt"))
         logger.info("Open folder: %s", pform.gui_select_dir("/tmp"))

--- a/d_rats/dplatform.py
+++ b/d_rats/dplatform.py
@@ -1,7 +1,7 @@
 '''
 D-Rats Platform.
 
-The Plaform class is intended to be a Singleton class.
+The Platform class is intended to be a Singleton class.
 
 The specific platform subclass is duck typed as the class to be used.
 '''

--- a/d_rats/dplatform_generic.py
+++ b/d_rats/dplatform_generic.py
@@ -18,6 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+# import mimetypes
 import os
 import shutil
 import subprocess
@@ -281,21 +282,43 @@ class PlatformGeneric():
         return "."
 
     @staticmethod
-    def gui_open_file(start_dir=None):
+    def gui_open_file(mime_types=None, start_dir=None):
         '''
         GUI Open File.
 
+        :type mime_types: list[str]
+        :returns: Filename or None
         :param start_dir: Directory to start in, default None
         :type start_dir: str
-        :returns: Filename or None
+        :param mime_types: Optional Mime types to filter
         :rtype: str
         '''
         dlg = Gtk.FileChooserDialog(
-            title="Select a file to open",
+            title=_("Select a file to open"),
             action=Gtk.FileChooserAction.OPEN)
         dlg.add_buttons(_("Cancel"),
                         Gtk.ResponseType.CANCEL,
                         _("Open"), Gtk.ResponseType.OK)
+
+        # This code should work, but does not in D-Rats on my Anti-X test
+        # system and it looks like it will take some time to debug.
+        # If the filter is added, only directories are displayed.
+        # if mime_types:
+        #    filter = Gtk.FileFilter()
+        #    for mime_type in mime_types:
+        #        exts = mimetypes.guess_all_extensions(mime_type, strict=True)
+        #        filter.set_name=(exts)
+                # In this case it does not seem to matter what string was
+                # passed to the filter, the filter shows up as unamed.
+                # This issue does not reproduce in a quick test program.
+        #        filter.add_mime_type=(mime_type)
+        #       dlg.add_filter(filter)
+        #    filter_any = Gtk.FileFilter()
+        #    filter_any.set_name(_("All files"))
+            # In this case the filter name gets set prpoerly unlike above.
+        #    filter_any.add_pattern=('*')
+        #    dlg.add_filter(filter_any)
+
         if start_dir and os.path.isdir(start_dir):
             dlg.set_current_folder(start_dir)
 
@@ -308,10 +331,12 @@ class PlatformGeneric():
         return None
 
     @staticmethod
-    def gui_save_file(start_dir=None, default_name=None):
+    def gui_save_file(mime_types=None, start_dir=None, default_name=None):
         '''
         GUI Save File.
 
+        :param mime_types: Optional Mime types to filter
+        :type mime_types: list[str]
         :param start_dir: Directory to start in, default None
         :type start_dir: str
         :param default_name: Default filename, default None
@@ -320,11 +345,21 @@ class PlatformGeneric():
         :rtype: str
         '''
         dlg = Gtk.FileChooserDialog(
-            title="Save file as",
+            title=_("Save file as"),
             action=Gtk.FileChooserAction.SAVE)
         dlg.add_buttons(_("Cancel"),
                         Gtk.ResponseType.CANCEL,
                         _("Save"), Gtk.ResponseType.OK)
+        # See gui_open_file
+        # if mime_types:
+        #    filter = Gtk.FileFilter()
+        #    for mime_type in mime_types:
+        #        filter.add_mime_type=(mime_type)
+        #    dlg.add_filter(filter)
+        #    filter_any = Gtk.FileFilter()
+        #    filter_any.set_name(_("All files"))
+        #    filter_any.add_pattern=("*")
+        #    dlg.add_filter(filter_any)
         if start_dir and os.path.isdir(start_dir):
             dlg.set_current_folder(start_dir)
 
@@ -350,7 +385,7 @@ class PlatformGeneric():
         :rtype: str
         '''
         dlg = Gtk.FileChooserDialog(
-            title="Choose folder",
+            title=_("Choose folder"),
             action=Gtk.FileChooserAction.SELECT_FOLDER)
         dlg.add_buttons(_("Cancel"),
                         Gtk.ResponseType.CANCEL,

--- a/d_rats/dplatform_generic.py
+++ b/d_rats/dplatform_generic.py
@@ -282,6 +282,7 @@ class PlatformGeneric():
         return "."
 
     @staticmethod
+    # pylint: disable=unused-argument
     def gui_open_file(mime_types=None, start_dir=None):
         '''
         GUI Open File.
@@ -304,15 +305,15 @@ class PlatformGeneric():
         # system and it looks like it will take some time to debug.
         # If the filter is added, only directories are displayed.
         # if mime_types:
-        #    filter = Gtk.FileFilter()
+        #    filter_mime = Gtk.FileFilter()
         #    for mime_type in mime_types:
         #        exts = mimetypes.guess_all_extensions(mime_type, strict=True)
-        #        filter.set_name=(exts)
+        #        filter_mime.set_name=(exts)
                 # In this case it does not seem to matter what string was
-                # passed to the filter, the filter shows up as unamed.
+                # passed to the filter, the filter shows up as unnamed.
                 # This issue does not reproduce in a quick test program.
-        #        filter.add_mime_type=(mime_type)
-        #       dlg.add_filter(filter)
+        #        filter_mime.add_mime_type=(mime_type)
+        #        dlg.add_filter(filter_mime)
         #    filter_any = Gtk.FileFilter()
         #    filter_any.set_name(_("All files"))
             # In this case the filter name gets set prpoerly unlike above.
@@ -331,6 +332,7 @@ class PlatformGeneric():
         return None
 
     @staticmethod
+    # pylint: disable=unused-argument
     def gui_save_file(mime_types=None, start_dir=None, default_name=None):
         '''
         GUI Save File.
@@ -352,10 +354,10 @@ class PlatformGeneric():
                         _("Save"), Gtk.ResponseType.OK)
         # See gui_open_file
         # if mime_types:
-        #    filter = Gtk.FileFilter()
+        #    filter_mime = Gtk.FileFilter()
         #    for mime_type in mime_types:
-        #        filter.add_mime_type=(mime_type)
-        #    dlg.add_filter(filter)
+        #        filter_mime.add_mime_type=(mime_type)
+        #    dlg.add_filter(filter_mime)
         #    filter_any = Gtk.FileFilter()
         #    filter_any.set_name(_("All files"))
         #    filter_any.add_pattern=("*")

--- a/d_rats/dplatform_win32.py
+++ b/d_rats/dplatform_win32.py
@@ -157,7 +157,7 @@ class Win32Platform(PlatformGeneric):
     @staticmethod
     def _mime_to_filter(mime_types):
         '''
-        Mime types to Microsoft Fitering.
+        Mime types to Microsoft Filtering.
 
         :param mime_types: A list of wanted mime types
         :type mime_type: list[str]
@@ -166,7 +166,7 @@ class Win32Platform(PlatformGeneric):
         '''
         if not mime_types:
             return None
-        filter=''
+        win_filter=''
         for mime_type in mime_types:
             exts = mimetypes.guess_all_extensions(mime_type, strict=True)
             ext_str = ''
@@ -174,9 +174,9 @@ class Win32Platform(PlatformGeneric):
                 ext_str = '*' + ext + ';'
             if ext_str:
                 new_filter = mime_type + '\\0' + ext_str + '\\0'
-                filter += new_filter
-        if filter:
-            return filter
+                win_filter += new_filter
+        if win_filter:
+            return win_filter
         return None
 
     def gui_open_file(self, mime_types=None, start_dir=None):

--- a/d_rats/dplatform_win32.py
+++ b/d_rats/dplatform_win32.py
@@ -18,6 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import mimetypes
 import os
 
 # There has been some problems with various Windows Python
@@ -153,18 +154,46 @@ class Win32Platform(PlatformGeneric):
                              "win32con or other python package missing!")
         return ports
 
-    def gui_open_file(self, start_dir=None):
+    @staticmethod
+    def _mime_to_filter(mime_types):
+        '''
+        Mime types to Microsoft Fitering.
+
+        :param mime_types: A list of wanted mime types
+        :type mime_type: list[str]
+        :returns: Microsoft file filter string
+        :rtype: str
+        '''
+        if not mime_types:
+            return None
+        filter=''
+        for mime_type in mime_types:
+            exts = mimetypes.guess_all_extensions(mime_type, strict=True)
+            ext_str = ''
+            for ext in exts:
+                ext_str = '*' + ext + ';'
+            if ext_str:
+                new_filter = mime_type + '\\0' + ext_str + '\\0'
+                filter += new_filter
+        if filter:
+            return filter
+        return None
+
+    def gui_open_file(self, mime_types=None, start_dir=None):
         '''
         GUI open file.
 
+        :param mime_types: Optional Mime types to filter
+        :type mime_types: list[str]
         :param start_dir: Directory to start in, default None
         :type start_dir: str
         :returns: Filename to open or none.
         :rtype: str
         '''
+        win_filter = self._mime_to_filter(mime_types=mime_types)
         try:
             fname, _filter, __flags = \
-                win32gui.GetOpenFileNameW()  # type: ignore
+                win32gui.GetOpenFileNameW(Filter=win_filter)  # type: ignore
             return str(fname)
         except pywintypes.error as err:  # type: ignore
             self.logger.info("gui_open_file: Failed to get filename: %s", err)
@@ -174,20 +203,22 @@ class Win32Platform(PlatformGeneric):
         return None
 
 
-    def gui_save_file(self, start_dir=None, default_name=None):
+    def gui_save_file(self, mime_types=None, start_dir=None, default_name=None):
         '''
         GUI Save File.
 
+        :param mime_types: Optional Mime types to filter
+        :type mime_types: list[str]
         :param start_dir: directory to start in, default None
-        :type default_name: str
-        :param default_name: Default name of file, default None.
         :type default_name: str
         :returns: filename to save to or None
         :rtype: str
         '''
+        win_filter = self._mime_to_filter(mime_types)
         try:
             fname, _filter, _flags = \
-                win32gui.GetSaveFileNameW(File=default_name)  # type: ignore
+                win32gui.GetSaveFileNameW(File=default_name,
+                                          Filter=win_filter)  # type: ignore
             return str(fname)
         except pywintypes.error as err:  # type: ignore
             self.logger.info("gui_save_file: Failed to get filename: %s", err)

--- a/d_rats/filenamebox.py
+++ b/d_rats/filenamebox.py
@@ -1,0 +1,154 @@
+'''Filename Box Class.'''
+# Copyright 2008 Dan Smith <dsmith@danplanet.com>
+# Copyright 2021-2022 John. E. Malmberg - Python3 Conversion
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import os
+
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+from gi.repository import GObject
+
+from .dplatform import Platform
+
+
+class FilenameBox(Gtk.Box):
+    '''
+    File Name Box.
+
+    :params find_dir: Find directory, default False
+    :type find_dir: bool
+    :params save: File is for saving, default False
+    :type save: bool
+    :param types: types, default []
+    :type types: list[str]
+    '''
+    __gsignals__ = {
+        "filename-changed" : (GObject.SignalFlags.RUN_LAST,
+                              GObject.TYPE_NONE, ()),
+        }
+
+    def __init__(self, find_dir=False, types=None, save=True):
+        Gtk.Box.__init__(self,
+                         orientation=Gtk.Orientation.HORIZONTAL,
+                         spacing=0)
+
+        if types:
+            self.types = types
+        else:
+            self.types = []
+
+        self.save = save
+        self.filename = Gtk.Entry()
+        self.filename.show()
+        self.pack_start(self.filename, 1, 1, 1)
+
+        browse = Gtk.Button.new_with_label("...")
+        browse.show()
+        self.pack_start(browse, 0, 0, 0)
+
+        self.filename.connect("changed", self.do_changed)
+        browse.connect("clicked", self.do_browse, find_dir)
+
+    def do_browse(self, _button, directory):
+        '''
+        Do Browse Button Handler.
+
+        :param _button: Button widget
+        :type _button: :class:`Gtk.Button`
+        :param directory: Is a directory
+        :type directory: bool
+        '''
+        if self.filename.get_text():
+            start = os.path.dirname(self.filename.get_text())
+        else:
+            start = None
+
+        if directory:
+            fname = Platform.get_platform().gui_select_dir(start)
+        elif self.save:
+            fname = Platform.get_platform().gui_save_file(start)
+        else:
+            fname = Platform.get_platform().gui_open_file(start)
+        if fname:
+            self.filename.set_text(fname)
+
+    def do_changed(self, _dummy):
+        '''
+        Do Changed Handler.
+
+        :param _dummy: Unused
+        '''
+        self.emit("filename_changed")
+
+    def set_filename(self, fname):
+        '''
+        Set Filename.
+
+        :param fname: File name
+        :type fname: str
+        '''
+        self.filename.set_text(fname)
+
+    def get_filename(self):
+        '''
+        Get Filename.
+
+        :returns: Filename
+        :rtype: str
+        '''
+        return self.filename.get_text()
+
+    # WB8TYW: I can not find a caller of this method.
+    def set_mutable(self, mutable):
+        '''
+        Set Mutable.
+
+        :param mutable: Set mutable property
+        :type mutable: bool
+        '''
+        self.filename.set_sensitive(mutable)
+
+
+def test():
+    '''Unit Test for Filenamebox.'''
+
+    logging.basicConfig(format="%(asctime)s:%(levelname)s:%(name)s:%(message)s",
+                        datefmt="%m/%d/%Y %H:%M:%S",
+                        level=logging.INFO)
+    logger = logging.getLogger("test_filenamebox")
+
+    win = Gtk.Window(type=Gtk.WindowType.TOPLEVEL)
+    win.connect("destroy", Gtk.main_quit)
+
+    filename_box1 = FilenameBox(save=False)
+
+    win.add(filename_box1)
+    filename_box1.show()
+    win.show()
+
+    filename = filename_box1.get_filename()
+
+    try:
+        Gtk.main()
+    except KeyboardInterrupt:
+        pass
+
+    logger.info(filename)
+
+if __name__ == "__main__":
+    test()

--- a/d_rats/filenamebox.py
+++ b/d_rats/filenamebox.py
@@ -30,27 +30,24 @@ class FilenameBox(Gtk.Box):
     '''
     File Name Box.
 
+    :param mime_types: Optional Mime types to filter, detault None
+    :type mime_types: list[str]
     :params find_dir: Find directory, default False
     :type find_dir: bool
     :params save: File is for saving, default False
     :type save: bool
-    :param types: types, default []
-    :type types: list[str]
     '''
     __gsignals__ = {
         "filename-changed" : (GObject.SignalFlags.RUN_LAST,
                               GObject.TYPE_NONE, ()),
         }
 
-    def __init__(self, find_dir=False, types=None, save=True):
+    def __init__(self, mime_types=None, find_dir=False, save=True):
         Gtk.Box.__init__(self,
                          orientation=Gtk.Orientation.HORIZONTAL,
                          spacing=0)
 
-        if types:
-            self.types = types
-        else:
-            self.types = []
+        self.mime_types = mime_types
 
         self.save = save
         self.filename = Gtk.Entry()
@@ -78,12 +75,15 @@ class FilenameBox(Gtk.Box):
         else:
             start = None
 
+        platform = Platform.get_platform()
         if directory:
-            fname = Platform.get_platform().gui_select_dir(start)
+            fname = platform.gui_select_dir(start_dir=start)
         elif self.save:
-            fname = Platform.get_platform().gui_save_file(start)
+            fname = platform.gui_save_file(mime_types=self.mime_types,
+                                           start_dir=start)
         else:
-            fname = Platform.get_platform().gui_open_file(start)
+            fname = platform.gui_open_file(mime_types=self.mime_types,
+                                           start_dir=start)
         if fname:
             self.filename.set_text(fname)
 
@@ -125,7 +125,7 @@ class FilenameBox(Gtk.Box):
 
 
 def test():
-    '''Unit Test for Filenamebox.'''
+    '''Unit Test for FilenameBox.'''
 
     logging.basicConfig(format="%(asctime)s:%(levelname)s:%(name)s:%(message)s",
                         datefmt="%m/%d/%Y %H:%M:%S",

--- a/d_rats/filenamebox.py
+++ b/d_rats/filenamebox.py
@@ -30,7 +30,7 @@ class FilenameBox(Gtk.Box):
     '''
     File Name Box.
 
-    :param mime_types: Optional Mime types to filter, detault None
+    :param mime_types: Optional Mime types to filter, default None
     :type mime_types: list[str]
     :params find_dir: Find directory, default False
     :type find_dir: bool

--- a/d_rats/miscwidgets.py
+++ b/d_rats/miscwidgets.py
@@ -18,7 +18,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import os
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -28,7 +27,6 @@ from gi.repository import GdkPixbuf
 from gi.repository import GObject
 from gi.repository import Pango
 
-from .dplatform import Platform
 from .dratsexception import LatLonEntryParseDMSError
 from .dratsexception import LatLonEntryValueError
 
@@ -1224,97 +1222,6 @@ def make_choice(options, editable=True, default=None):
         except ValueError:
             pass
     return sel
-
-
-class FilenameBox(Gtk.Box):
-    '''
-    File Name Box.
-
-    :params find_dir: Find directory, default False
-    :type find_dir: bool
-    :param types: types, default []
-    :type types: list
-    '''
-    __gsignals__ = {
-        "filename-changed" : (GObject.SignalFlags.RUN_LAST,
-                              GObject.TYPE_NONE, ()),
-        }
-
-    def __init__(self, find_dir=False, types=None):
-        Gtk.Box.__init__(self, Gtk.Orientation.HORIZONTAL, 0)
-
-        if types:
-            self.types = types
-        else:
-            self.types = []
-
-        self.filename = Gtk.Entry()
-        self.filename.show()
-        self.pack_start(self.filename, 1, 1, 1)
-
-        browse = Gtk.Button.new_with_label("...")
-        browse.show()
-        self.pack_start(browse, 0, 0, 0)
-
-        self.filename.connect("changed", self.do_changed)
-        browse.connect("clicked", self.do_browse, find_dir)
-
-    def do_browse(self, _button, directory):
-        '''
-        Do Browse Button Handler.
-
-        :param _button: Button widget
-        :type _button: :class:`Gtk.Button`
-        :param directory: Is a directory
-        :type directory: bool
-        '''
-        if self.filename.get_text():
-            start = os.path.dirname(self.filename.get_text())
-        else:
-            start = None
-
-        if directory:
-            fname = Platform.get_platform().gui_select_dir(start)
-        else:
-            fname = Platform.get_platform().gui_save_file(start)
-        if fname:
-            self.filename.set_text(fname)
-
-    def do_changed(self, _dummy):
-        '''
-        Do Changed Handler.
-
-        :param _dummy: Unused
-        '''
-        self.emit("filename_changed")
-
-    def set_filename(self, fname):
-        '''
-        Set Filename.
-
-        :param fname: File name
-        :type fname: str
-        '''
-        self.filename.set_text(fname)
-
-    def get_filename(self):
-        '''
-        Get Filename.
-
-        :returns: Filename
-        :rtype: str
-        '''
-        return self.filename.get_text()
-
-    # WB8TYW: I can not find a caller of this method.
-    def set_mutable(self, mutable):
-        '''
-        Set Mutable.
-
-        :param mutable: Set mutable property
-        :type mutable: bool
-        '''
-        self.filename.set_sensitive(mutable)
 
 
 def make_pixbuf_choice(options, default=None):

--- a/d_rats/qst.py
+++ b/d_rats/qst.py
@@ -34,8 +34,9 @@ if not '_' in locals():
     import gettext
     _ = gettext.gettext
 
+from .filenamebox import FilenameBox
 from .miscwidgets import make_choice
-from . import miscwidgets
+from .miscwidgets import make_pixbuf_choice
 
 from .dplatform import Platform
 from . import inputdialog
@@ -98,9 +99,9 @@ def do_dprs_calculator(initial=""):
         icon = get_icon(sym)
         if icon:
             icons.append((icon, sym))
-    iconsel = miscwidgets.make_pixbuf_choice(icons, deficn)
+    iconsel = make_pixbuf_choice(icons, deficn)
 
-    oversel = miscwidgets.make_choice(overlays, False, defovr)
+    oversel = make_choice(overlays, False, defovr)
     iconsel.connect("changed", ev_sym_changed, oversel, icons)
     ev_sym_changed(iconsel, oversel, icons)
 
@@ -824,13 +825,17 @@ class QSTEditWidget(Gtk.Box):
     '''
     QST Edit Widget.
 
-    :param a: :class:`Gtk.Box` arguments
-    :param k: :class: `Gtk.Box` Keyword arguments
+    :param orientation: Orientation for the Gtk Box.
+    :type orientation: :class:`Gtk.Orientation`,
+                       default Gtk.Orientation.VERTICAL
+    :param spacing: the number of pixels between children
+    :type: spacing: int
     '''
 
-    def __init__(self, *a, **k):
-        Gtk.Box.__init__(self, *a, **k)
-        self.set_orientation(Gtk.Orientation.VERTICAL)
+    def __init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=0):
+        Gtk.Box.__init__(self)
+        self.set_orientation(orientation)
+        self.set_spacing(spacing)
         self._id = None
 
     def to_qst(self):
@@ -871,7 +876,7 @@ class QSTTextEditWidget(QSTEditWidget):
     label_text = _("Enter a message:")
 
     def __init__(self):
-        QSTEditWidget.__init__(self, False, 2)
+        QSTEditWidget.__init__(self, spacing=2)
 
         lab = Gtk.Label.new(self.label_text)
         lab.show()
@@ -927,14 +932,14 @@ class QSTFileEditWidget(QSTEditWidget):
                    "The contents will be used when the QST is sent.")
 
     def __init__(self):
-        QSTEditWidget.__init__(self, False, 2)
+        QSTEditWidget.__init__(self, spacing=2)
 
         lab = Gtk.Label.new(self.label_text)
         lab.set_line_wrap(True)
         lab.show()
         self.pack_start(lab, 1, 1, 1)
 
-        self.__fn = miscwidgets.FilenameBox()
+        self.__fn = FilenameBox(save=False)
         self.__fn.show()
         self.pack_start(self.__fn, 0, 0, 0)
 
@@ -980,14 +985,13 @@ class QSTWXFileEditWidget(QSTEditWidget):
                    "The contents will be used when the WXGPS-A is sent.")
 
     def __init__(self):
-        QSTEditWidget.__init__(self, False, 2)
-
+        QSTEditWidget.__init__(self, spacing=2)
         lab = Gtk.Label(self.label_text)
         lab.set_line_wrap(True)
         lab.show()
         self.pack_start(lab, 1, 1, 1)
 
-        self.__fn = miscwidgets.FilenameBox()
+        self.__fn = FilenameBox(save=False)
         self.__fn.show()
         self.pack_start(self.__fn, 0, 0, 0)
 
@@ -1043,7 +1047,7 @@ class QSTGPSEditWidget(QSTEditWidget):
     type = "GPS"
 
     def __init__(self, config):
-        QSTEditWidget.__init__(self, False, 2)
+        QSTEditWidget.__init__(self, spacing=2)
 
         lab = Gtk.Label.new(_("Enter your GPS message:"))
         lab.set_line_wrap(True)
@@ -1136,8 +1140,7 @@ class QSTRSSEditWidget(QSTEditWidget):
     label_string = _("Enter the URL of an RSS feed:")
 
     def __init__(self):
-        QSTEditWidget.__init__(self, False, 2)
-
+        QSTEditWidget.__init__(self, spacing=2)
         lab = Gtk.Label.new(self.label_string)
         lab.show()
         self.pack_start(lab, 1, 1, 1)
@@ -1192,7 +1195,7 @@ class QSTStationEditWidget(QSTEditWidget):
     '''QST Station Edit Widget.'''
 
     def __init__(self):
-        QSTEditWidget.__init__(self, False, 2)
+        QSTEditWidget.__init__(self, spacing=2)
 
         lab = Gtk.Label.new(_("Choose a station whose position will be sent"))
         lab.show()
@@ -1206,13 +1209,11 @@ class QSTStationEditWidget(QSTEditWidget):
         from . import mainapp
         self.__sources = mainapp.get_mainapp().map.get_map_sources()
         sources = [x.get_name() for x in self.__sources]
-        self.__group = miscwidgets.make_choice(sources,
-                                               False,
-                                               _("Stations"))
+        self.__group = make_choice(sources, False, _("Stations"))
         self.__group.show()
         hbox.pack_start(self.__group, 0, 0, 0)
 
-        self.__station = miscwidgets.make_choice([], False)
+        self.__station = make_choice([], False)
         self.__station.show()
         hbox.pack_start(self.__station, 0, 0, 0)
 
@@ -1284,7 +1285,7 @@ class QSTWUEditWidget(QSTEditWidget):
     label_text = _("Enter an Open Weather station name:")
 
     def __init__(self):
-        QSTEditWidget.__init__(self)
+        QSTEditWidget.__init__(self, spacing=2)
 
         lab = Gtk.Label.new(self.label_text)
         lab.show()
@@ -1301,7 +1302,7 @@ class QSTWUEditWidget(QSTEditWidget):
         hbox.pack_start(self.__station, 0, 0, 0)
 
         types = [_("Current"), _("Forecast")]
-        self.__type = miscwidgets.make_choice(types, False, types[0])
+        self.__type = make_choice(types, False, types[0])
         self.__type.show()
         hbox.pack_start(self.__type, 0, 0, 0)
 
@@ -1407,7 +1408,7 @@ class QSTEditDialog(Gtk.Dialog):
         self.__current.show()
 
     def _make_controls(self):
-        hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 5)
+        hbox = Gtk.Box.new(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)
 
         self._type = make_choice(list(self._types.keys()),
                                  False, default=_("Text"))

--- a/docs/source/d_rats.rst
+++ b/docs/source/d_rats.rst
@@ -149,6 +149,14 @@ d\_rats.emailgw module
     :undoc-members:
     :show-inheritance:
 
+d\_rats.filenamebox module
+--------------------------
+
+.. automodule:: d_rats.filenamebox
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 d\_rats.formbuilder module
 --------------------------
 


### PR DESCRIPTION
d_rats/config.py:
  Use refactored d_rats/filenamebox.py.
  Designate when not a save file operation.

d_rats/filenamebox.py:
  Refactored from d_rats/miscwidgets.py.
  Fix GTK compatibility issues.
  Add save parameter to select proper action button.
  Add Unit test.

d_rats/miscwidgets.py:
  Remove FilenameBox class.

d_rats/qst.py:
  Use refactored d_rats/filenamebox.py.
  Fix GTK compatibility issues.

docs/source/d_rats.rst:
  Add d_rats/filenamebox.py