### PR TITLE
NMEA conversions and MAP fixes

### DIFF
--- a/changes/211.bugfix
+++ b/changes/211.bugfix
@@ -1,2 +1,1 @@
 Fix NMEA to decimal degree conversions.
-Add correction for latitude display on Map.

--- a/changes/211.bugfix
+++ b/changes/211.bugfix
@@ -1,0 +1,2 @@
+Fix NMEA to decimal degree conversions.
+Add correction for latitude display on Map.

--- a/d_rats/gps.py
+++ b/d_rats/gps.py
@@ -354,7 +354,7 @@ def deg2dm(decdeg):
     :param decdeg: Degrees value
     :type decdeg: float
     :returns: Tuple of degree and minutes
-    :rtype: tuple[float, float]
+    :rtype: tuple[int, float]
     '''
     deg = int(decdeg)
     minutes = (decdeg - deg) * 60.0
@@ -373,11 +373,8 @@ def nmea2deg(nmea, direction="N"):
     :returns: Degrees
     :rtype: float
     '''
-    deg = int(nmea) / 100
-    try:
-        minutes = nmea % (deg * 100)
-    except ZeroDivisionError:
-        minutes = int(nmea)
+    deg = int(nmea / 100)
+    minutes = nmea - (deg * 100)
 
     if direction in ["S", "W"]:
         multiplier = -1
@@ -527,9 +524,9 @@ class GPSPosition():
     :param station: Station, default "UNKNOWN"
     :type station: str
     '''
+    logger = logging.getLogger("GPSPosition")
 
     def __init__(self, lat=0, lon=0, station=None):
-        self.logger = logging.getLogger("GPSPosition")
         self.valid = False
         self.altitude = 0
         self.satellites = 0
@@ -958,10 +955,10 @@ class NMEAGPSPosition(GPSPosition):
     :param station: Station, default _("UNKNOWN")
     :raises: GpsGpggaException classes on error.
     '''
+    logger = logging.getLogger("NMEAGPSPosition")
 
     def __init__(self, sentence, station=None):
         GPSPosition.__init__(self)
-        self.logger = logging.getLogger("NMEAGPSPosition")
         self.latitude = None
         self.longitude = None
 
@@ -1110,12 +1107,12 @@ class NMEAGPSPosition(GPSPosition):
 
 class APRSGPSPosition(GPSPosition):
     '''APRS GPS Position.'''
+    logger = logging.getLogger("APRSGPSPosition")
 
     def __init__(self, message):
         self.latitude = None
         self.longitude = None
         GPSPosition.__init__(self)
-        self.logger = logging.getLogger("APRSGPSPosition")
 
         self._from_aprs(message)
 
@@ -1228,9 +1225,9 @@ class MapImage():
 
     :param center: Center of map
     '''
+    logger = logging.getLogger("MapImage")
 
     def __init__(self, center):
-        self.logger = logging.getLogger("MapImage")
         self.key = "ABQIAAAAWot3KuWpenfCAGfQ65FdzRTaP0xjRaMPpcw6bBbU" \
                    "2QUEXQBgHBR5Rr2HTGXYVWkcBFNkPvxtqV4VLg"
         self.center = center
@@ -1324,9 +1321,9 @@ class GPSSource():
     :param rate: Baud rate, default=4800
     :type rate: int
     '''
+    logger = logging.getLogger("GPSSource")
 
     def __init__(self, port, rate=4800):
-        self.logger = logging.getLogger("GPSSource")
         self.port = port
         self.enabled = False
         self.broken = None
@@ -1425,10 +1422,10 @@ class NetworkGPSSource(GPSSource):
     :param port: Radio port
     :type port: str
     '''
+    logger = logging.getLogger("NetworkGPSSource")
 
     # pylint: disable=super-init-not-called
     def __init__(self, port):
-        self.logger = logging.getLogger("NetworkGPSSource")
         self.port = port
         self.enabled = False
         self.thread = None
@@ -1554,10 +1551,10 @@ class StaticGPSSource(GPSSource):
     :param station: Station for source, default 'Unknown'
     :type station: str
     '''
+    logger = logging.getLogger("StaticGPSSource")
 
     # pylint: disable=super-init-not-called
     def __init__(self, lat, lon, alt=0, station=None):
-        self.logger = logging.getLogger("StaticGPSSource")
         self.lat = lat
         self.lon = lon
         self.alt = alt

--- a/d_rats/map/maptile.py
+++ b/d_rats/map/maptile.py
@@ -95,7 +95,6 @@ class MapTile():
     _proxy = None
     _tile_lifetime = 0
     _zoom = 0
-    _fudge = {'x': 2, 'y': 12.5}
     _num_tiles = 0
     _map_widget = None
     _tilesize = 256
@@ -121,7 +120,6 @@ class MapTile():
             self.x_tile, self.y_tile, self.x_fraction, self.y_fraction = \
                self.deg2tile(self.position)
             # Convert the tile coordinates back to the latitude, longitude
-            # as a possible way to determine a future fudge factor.
             self.tile_position = self.num2deg(self.x_tile + self.x_fraction,
                                               self.y_tile + self.y_fraction)
         else:
@@ -291,17 +289,16 @@ class MapTile():
         # off by this approximate amount, which seems to be
         # related to the zoom level until zoom level 14, and
         # then becomes constant.
-        divisor = 2 ** (18 - cls._zoom)
-        # cls._fudge['x'] = max(16 / divisor, 2)
-        cls._fudge['x'] = 0
-        cls._fudge['y'] = max(208 / (divisor), 12)
-        cls.logger.debug("fudge %s", cls._fudge)
+        cls.logger.info("zoom: x_tile %s y_tile %s",
+                        cls.center.x_tile, cls.center.y_tile)
+        cls._set_x_origin()
         if not cls._center:
             return
-        cls._set_x_origin()
 
     # The deg2xxx functions derived from:
     #   http://wiki.openstreetmap.org/wiki/Slippy_map_tilenames
+    # On Jul 1, 2023, the python example there is wrong,
+    # look at the algorithm and the ruby example.
     @classmethod
     def deg2num(cls, position):
         '''
@@ -351,8 +348,8 @@ class MapTile():
         x_tile_decimal, y_tile_decimal = cls.deg2num(position)
         x_tile_decimal -= cls._x_origin
         y_tile_decimal -= cls._y_origin
-        x_display = (x_tile_decimal * cls._tilesize) + cls._fudge['x']
-        y_display = y_tile_decimal * cls._tilesize - cls._fudge['y']
+        x_display = x_tile_decimal * cls._tilesize
+        y_display = y_tile_decimal * cls._tilesize
         return (x_display, y_display)
 
     # The deg2num function derived from:
@@ -394,8 +391,8 @@ class MapTile():
         :returns: Map position in longitude and latitude degrees
         :rtype: :class:`Map.MapPosition`
         '''
-        x_tile_decimal = (display_x - cls._fudge['x']) / cls._tilesize
-        y_tile_decimal = (display_y + cls._fudge['y']) / cls._tilesize
+        x_tile_decimal = (display_x ) / cls._tilesize
+        y_tile_decimal = (display_y ) / cls._tilesize
         cls.logger.info("x_tile %f, y_tile %f",
                         x_tile_decimal, y_tile_decimal)
 

--- a/d_rats/map/maptile.py
+++ b/d_rats/map/maptile.py
@@ -385,11 +385,8 @@ class MapTile():
         :returns: Map position in longitude and latitude degrees
         :rtype: :class:`Map.MapPosition`
         '''
-        x_tile_decimal = (display_x ) / cls._tilesize
-        y_tile_decimal = (display_y ) / cls._tilesize
-        cls.logger.info("x_tile %f, y_tile %f",
-                        x_tile_decimal, y_tile_decimal)
-
+        x_tile_decimal = display_x / cls._tilesize
+        y_tile_decimal = display_y / cls._tilesize
         tile_pos = cls.num2deg(x_tile_decimal + cls._x_origin,
                                y_tile_decimal + cls._y_origin)
         return tile_pos

--- a/d_rats/map/maptile.py
+++ b/d_rats/map/maptile.py
@@ -285,15 +285,9 @@ class MapTile():
         '''
         cls._zoom = zoom
         cls._num_tiles = pow(2, cls._zoom)
-        # For some unknown reason positions on the map are
-        # off by this approximate amount, which seems to be
-        # related to the zoom level until zoom level 14, and
-        # then becomes constant.
-        cls.logger.info("zoom: x_tile %s y_tile %s",
-                        cls.center.x_tile, cls.center.y_tile)
-        cls._set_x_origin()
         if not cls._center:
             return
+        cls._set_x_origin()
 
     # The deg2xxx functions derived from:
     #   http://wiki.openstreetmap.org/wiki/Slippy_map_tilenames

--- a/d_rats/map/mapwindow.py
+++ b/d_rats/map/mapwindow.py
@@ -82,13 +82,13 @@ class MapWindow(Gtk.ApplicationWindow):
     STATUS_COORD = 0
     STATUS_CENTER = 1
     STATUS_GPS = 2
+    logger = logging.getLogger("MapWindow")
 
     # pylint wants only 50 statements per method
     # pylint: disable=too-many-statements
     def __init__(self, application, config):
         Gtk.ApplicationWindow.__init__(self, application=application)
 
-        self.logger = logging.getLogger("MapWindow")
         self.application = application
 
         self.connect("destroy", self.ev_destroy)
@@ -588,8 +588,8 @@ class MapWindow(Gtk.ApplicationWindow):
 
         position = Map.Tile.display2deg(mx_axis, my_axis)
 
-        self.logger.info("Button %i at %i,%i",
-                         event.button, mx_axis, my_axis)
+        self.logger.debug("Button %i at %i,%i",
+                          event.button, mx_axis, my_axis)
         # Need to test for _2BUTTON_PRESS before testing
         # for a normal button press.
         # This is not a protected-access, it is the actual

--- a/d_rats/map/mapzoomcontrols.py
+++ b/d_rats/map/mapzoomcontrols.py
@@ -22,7 +22,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-# import logging
 import time
 
 import gi
@@ -185,6 +184,7 @@ class MapZoomControls(Gtk.Frame):
             self.__prev_level = zoom_value
             Map.Tile.set_zoom(zoom_value)
             Map.Draw.set_zoom_changed()
+            self.map_widget.zoom_changed()
             # This should signal a map redraw event
             self.map_widget.queue_draw()
         return False


### PR DESCRIPTION
Fix NMEA to decimal degree conversions.
Add correction for latitude display on Map.

d_rats/gps.py:
  Move logger to be a class variable.
  Fix nmea2deg routine.

d_rats/map/mapwidget.py:
  Move logger to be a class variable.
  Only recalculate map scale on zoom change.

d_rats/map/maptile.py:
  Move logger to be a class variable.
  Add fudge factor to correct latitude placement.

d_rats/map/mapwindow.py:
  Move logger to be a class variable.
  Adjust event button to be debug logging item.

d_rats/map/mapzoomcontrols.py:
  Need to have mapwidget update scale text on zoom change.

changes/211.bugfix:
  Describe NMEA and decimal Degree fixes.