### PR TITLE
Fixes for version.py and d-rats_repeater.py

### DIFF
--- a/d-rats_repeater.py
+++ b/d-rats_repeater.py
@@ -1068,7 +1068,7 @@ class RepeaterGUI(RepeaterUI):
         # self.config.set("settings", "idfreq", idfreq)
         self.config.set("settings", "netport", port)
         self.config.set("settings", "acceptnet", acceptnet)
-        self.config.set("settings", "devices", devices)
+        self.config.set("settings", "devices", str(devices))
         self.config.set("settings", "require_auth", str(auth))
         self.config.set("settings", "trust_local", str(local))
         self.config.set("settings", "gpsport", gpsport)

--- a/d_rats/version.py
+++ b/d_rats/version.py
@@ -365,7 +365,7 @@ class Version:
                 cls._parse_version(raw_version)
                 cls._get_pep440_version()
                 cls._update_pkg_info(pkg_info_file)
-            except subprocess.CalledProcessError:
+            except (FileNotFoundError, subprocess.CalledProcessError):
                 cls.logger.info('Unable to get version number from git tags')
 
         if not cls._version:


### PR DESCRIPTION
d-rats_repeater.py:
  Fix saving of optional additional devices.

d_rats/version.py:
  Was not handling if the git program was not installed.