### PR TITLE
More XON/XOFF fixes

### DIFF
--- a/d-rats.py
+++ b/d-rats.py
@@ -45,6 +45,10 @@ except AttributeError:
 from d_rats.version import __version__
 from d_rats.version import DRATS_VERSION
 from d_rats.dplatform import Platform
+from d_rats import mainapp
+
+# Temporary to allow enabling serial port logging.
+from d_rats.comm import SWFSerial
 
 # Default gettext function which is needed for pylance
 # This global variable will be overridden by the mainapp module.
@@ -208,6 +212,9 @@ def main():
                         action="store_true",
                         help="Show version.")
 
+    parser.add_argument("--sdebug",
+                        action="store_true",
+                        help="Log serial port data.")
 
     args = parser.parse_args()
 
@@ -223,10 +230,10 @@ def main():
         MODULE_LOGGER.info("main: args.config = %s", args.config)
         platform.set_config_dir(args.config)
 
-
-    # import the D-Rats main application
-    # pylint: disable=import-outside-toplevel
-    from d_rats import mainapp
+    # This is temporary for debugging serial port radio transfers
+    if args.sdebug:
+        serial_log_file = platform.log_file('serial')
+        SWFSerial.set_log_file(serial_log_file)
 
      # stores away the value of sys.excepthook
     install_excepthook()

--- a/d_rats/comm.py
+++ b/d_rats/comm.py
@@ -389,7 +389,7 @@ class SWFSerial(serial.Serial):
         # Now we have a problem, it is a valid character.
         # old behavior was to discard it.
         elif len(char) == 1:
-            self.logger.info("is_xon: Aiee! Read a non-XOFF char: `%s`")
+            self.logger.info("is_xon: Aiee! Read a non-XOFF char: `%s`", char)
             self.state = True
             self.logger.info("is_xon: Assuming IXANY behavior")
             self.read_buffer += char
@@ -674,7 +674,7 @@ class SerialDataPath(DataPath):
                                      baudrate=self.baud,
                                      timeout=self.timeout,
                                      write_timeout=self.timeout,
-                                     xonxoff=True)
+                                     xonxoff=False)
         except (ValueError, serial.SerialException) as err:
             # pylint: disable=raise-missing-from
             raise DataPathNotConnectedError("Unable to open serial port %s" %
@@ -821,7 +821,7 @@ class TNCDataPath(SerialDataPath):
                                  baudrate=self.baud,
                                  timeout=self.timeout,
                                  write_timeout=self.timeout*10,
-                                 xonxoff=True)
+                                 xonxoff=False)
 
     def __str__(self):
         return "[TNC %s@%s]" % (self.port, self.baud)

--- a/d_rats/comm.py
+++ b/d_rats/comm.py
@@ -330,6 +330,7 @@ class SWFSerial(serial.Serial):
             self.use_dsr = kwargs["dsr_control"]
             del kwargs["dsr_control"]
         self.dsr_seen = False
+        self.read_buffer = b''
 
     def reconnect(self):
         '''Reconnect.'''
@@ -346,7 +347,10 @@ class SWFSerial(serial.Serial):
         '''
         Is in xon state?
 
-        :returns: True if data transmissions are allowed
+        Sets self.state if an XON/XOFF character is received.
+        Returns a character if anything other than XON/XOFF is received.
+
+        :returns: Current self.state
         :rtype: bool
         :raises: :class:`DataPathNotConnectedError` on serial port disconnect
         '''
@@ -360,38 +364,36 @@ class SWFSerial(serial.Serial):
             self.dsr_seen = True
         time.sleep(0.01)
         self.state = True  # Pending re-write
-        return True
-        # Code below has has always been wrong and will randomly result in
-        # data being lost.
-        # To avoid this D-Rats has been changed to use the serial driver
-        # xon/xoff protocol handling instead of this broken code.
+        # Code below is not optimmal, for some reason it almost works
+        #
+        # Using the serial driver xon/xoff protocol handling instead of
+        # this has been found not work in some cases.
         #
         # Bug #1 No code is present to detect if an XOFF or XON appears in
         # the middle of a data stream.
         # Bug #2 The XOFF/XON is not guaranteed to show up at the
         # beginnng of a read packet.
-        # Bug #3 If this code does not receive an XON or XOFF character
-        # it simply discards it, which breaks the radio transfer.
-
-        ### if self.in_waiting == 0:
-        ###     return self.state
-        ### char = serial.Serial.read(self, 1)
-        ### if char == ASCII_XOFF:
-        ###     if self.__swf_debug:
-        ###         self.logger.info("is_xon: ************* Got XOFF")
-        ###     self.state = False
-        ### elif char == ASCII_XON:
-        ###     if self.__swf_debug:
-        ###         self.logger.info("is_xon ------------- Got XON")
-        ###     self.state = True
-        ### #
-        ### elif len(char) == 1:
-        ###    self.logger.info("is_xon: Aiee! Read a non-XOFF char: `%s`")
-        ###    self.logger.info("This is bug in this code!")
-        ###    self.state = True
-        ###    self.logger.info("is_xon: Assuming IXANY behavior")
-        ###
-        ### return self.state
+        # Apparently the serial device is expected to send at least XON/XOFF to
+        # back to D-rats for every packet sent to it.
+        if self.in_waiting == 0:
+            return self.state
+        char = serial.Serial.read(self, 1)
+        if char == ASCII_XOFF:
+            if self.__swf_debug:
+                self.logger.info("is_xon: ************* Got XOFF")
+            self.state = False
+        elif char == ASCII_XON:
+            if self.__swf_debug:
+                self.logger.info("is_xon ------------- Got XON")
+            self.state = True
+        # Now we have a problem, it is a valid character.
+        # old behavior was to discard it.
+        elif len(char) == 1:
+            self.logger.info("is_xon: Aiee! Read a non-XOFF char: `%s`")
+            self.state = True
+            self.logger.info("is_xon: Assuming IXANY behavior")
+            self.read_buffer += char
+        return None
 
     def _write(self, data):
         if self.use_dsr and not self.dsr:
@@ -451,6 +453,17 @@ class SWFSerial(serial.Serial):
         :returns: data read
         :rtype: bytes
         '''
+        local_buffer = b''
+        # First return any bytes received while looking for
+        # XON/XOFF
+        buffer_count = len(self.read_buffer)
+        needed = size - buffer_count
+        if buffer_count > 0:
+            local_buffer = self.read_buffer[0:size]
+            self.read_buffer = self.read_buffer[size:]
+            if needed <= 0:
+                return local_buffer
+
         if self.use_dsr and not self.dsr:
             raise DataPathNotConnectedError("Serial port disconnected %s" %
                                             self.name)
@@ -459,8 +472,8 @@ class SWFSerial(serial.Serial):
                 self.logger.info("Serial port Connection Confirmed %s",
                                  self.name)
                 self.dsr_seen = True
-        return serial.Serial.read(self, size)
-
+        read_buf = serial.Serial.read(self, needed)
+        return local_buffer + read_buf
 
 class DataPath():
     '''

--- a/d_rats/config.py
+++ b/d_rats/config.py
@@ -1731,14 +1731,17 @@ class DratsRadioPanel(DratsPanel):
         list_widget = port_config_list.add_list(cols, make_key)
         add = Gtk.Button.new_with_label(_("Add"))
         add.connect("clicked", self.but_add, list_widget)
-        mod = Gtk.Button.new_with_label(_("Edit"))
-        mod.connect("clicked", self.but_mod, list_widget)
-        rem = Gtk.Button.new_with_label(_("Remove"))
-        rem.connect("clicked", self.but_rem, list_widget)
+        self.mod = Gtk.Button.new_with_label(_("Edit"))
+        self.mod.set_sensitive(False)
+        self.mod.connect("clicked", self.but_mod, list_widget)
+        self.rem = Gtk.Button.new_with_label(_("Remove"))
+        self.rem.set_sensitive(False)
+        self.rem.connect("clicked", self.but_rem, list_widget)
+        list_widget.treeview.connect("cursor-changed", self.cursor_changed)
 
         port_config_list.set_sort_column(6)
 
-        self.make_view(_("Paths"), port_config_list, add, mod, rem)
+        self.make_view(_("Paths"), port_config_list, add, self.mod, self.rem)
 
         list_widget.set_resizable(1, False)
 
@@ -1771,6 +1774,18 @@ class DratsRadioPanel(DratsPanel):
             self.attach_next_to(box, widgets[0], Gtk.PositionType.BOTTOM,
                                 1, box_height)
 
+    def cursor_changed(self, _tree_view):
+        '''
+        Cursor Changed Handler.
+
+        Triggered when the cursor for the row get changed.
+        :param _tree_view: List box with data, Unused
+        :type _tree_view: `:class:Gtk.TreeView`
+        '''
+        self.logger.info("cursor_changed tree_view: %s",
+                         type(_tree_view))
+        self.mod.set_sensitive(True)
+        self.rem.set_sensitive(True)
 
     @staticmethod
     def but_add(_button, list_widget):

--- a/d_rats/keyedlistwidget.py
+++ b/d_rats/keyedlistwidget.py
@@ -69,6 +69,13 @@ class KeyedListWidget(Gtk.Box):
         self._make_view()
         self.__view.show()
 
+    @property
+    def treeview(self):
+        '''
+        :returns: TreeView widget
+        :rtype: `:class:Gtk.Treeview`'''
+        return self.__view
+
     def _toggle(self, _rend, path, colnum):
         '''
         Internal Toggle handler.

--- a/d_rats/ui/main_files.py
+++ b/d_rats/ui/main_files.py
@@ -77,7 +77,12 @@ class FileView():
         self.outstanding = {}
 
     def get_path(self):
-        '''Get the Path.'''
+        '''
+        Get the local directory Path.
+
+        :returns: directory path
+        :rtype: str
+        '''
         return self._path
 
     def set_path(self, path):
@@ -250,7 +255,7 @@ class RemoteFileView(FileView):
         '''
         self._store.clear()
 
-        job = rpc.RPCFileListJob(self.get_path(), "File list request")
+        job = rpc.RPCFileListJob(dest=self.station, desc="File list request")
         job.connect("state-change", self._file_list_cb)
 
         return job
@@ -322,7 +327,7 @@ class FilesTab(MainWindowTab):
         if not self._remote:
             return
 
-        if self._remote.get_path() != job.get_dest():
+        if self._remote.station != job.get_dest():
             return
 
         self._stop_throb()
@@ -370,7 +375,7 @@ class FilesTab(MainWindowTab):
         if not sta or sta.upper() == REMOTE_HINT.upper():
             return
 
-        if not self._remote or self._remote.get_path() != sta:
+        if not self._remote or self._remote.station != sta:
             self._remote = RemoteFileView(view=view, path=None,
                                           config=self._config,
                                           station=sta)
@@ -483,7 +488,7 @@ class FilesTab(MainWindowTab):
         if not self._remote:
             return
 
-        station = self._remote.get_path()
+        station = self._remote.station
         file_name = self._remote.get_selected_filename()
 
         _ssel, psel = self._get_ssel()
@@ -496,7 +501,8 @@ class FilesTab(MainWindowTab):
                                                             result_code))
                 self._emit("event", event)
 
-        job = rpc.RPCPullFileJob(station, "Request file %s" % file_name)
+        job = rpc.RPCPullFileJob(dest=station,
+                                 desc="Request file %s" % file_name)
         job.connect("state-change", log_failure)
         job.set_file(file_name)
 
@@ -513,7 +519,7 @@ class FilesTab(MainWindowTab):
         :param _rfview: remote fileview, unused
         :type _rfview: `:class:RemoteFileView`
         '''
-        station = self._remote.get_path()
+        station = self._remote.station
 
         dialog = inputdialog.TextInputDialog()
         dialog.label.set_text(_("Password for %s (blank if none):" % station))

--- a/d_rats/ui/main_files.py
+++ b/d_rats/ui/main_files.py
@@ -168,11 +168,23 @@ class RemoteFileView(FileView):
     :type path: str
     :param config: Configuration data
     :type config: :class:`DratsConfig`
+    :param station; Remote Station, Optional
+    :type station: str
     '''
     logger = logging.getLogger("RemoteFileV")
 
-    def __init__(self, view, path, config):
+    def __init__(self, view, path, config, station=None):
         FileView.__init__(self, view, path, config)
+
+        self._station = station
+
+    @property
+    def station(self):
+        '''
+        :returns: Remote Station
+        :rtype: str
+        '''
+        return self._station
 
     def _file_list_cb(self, _job, state, result):
         '''
@@ -322,6 +334,14 @@ class FilesTab(MainWindowTab):
             self._disconnect(None, None)
 
     def _disconnect(self, _button, _rfview):
+        '''
+        Disconnect Button Handler.
+
+        :param _button: Button Widget, unused
+        :type _button: `:class:Gtk.Button`
+        :param _rfview: remote fileview, unused
+        :type _rfview: `:class:RemoteFileView`
+        '''
         if self._remote:
             view = self._remote.get_view()
             view.set_sensitive(False)
@@ -334,7 +354,14 @@ class FilesTab(MainWindowTab):
         self.emit("status", "Disconnected")
 
     def _connect_remote(self, _button, _rfview):
+        '''
+        Connect Button Handler.
 
+        :param _button: Button Widget, unused
+        :type _button: `:class:Gtk.Button`
+        :param _rfview: remote fileview, unused
+        :type _rfview: `:class:RemoteFileView`
+        '''
         view = self._get_widget("remote_list")
         ssel, psel = self._get_ssel()
         sta = ssel.get_active_text().upper()
@@ -345,7 +372,8 @@ class FilesTab(MainWindowTab):
 
         if not self._remote or self._remote.get_path() != sta:
             self._remote = RemoteFileView(view=view, path=None,
-                                          config=self._config)
+                                          config=self._config,
+                                          station=sta)
 
         throbber = self._get_widget("remote_throb")
         img = self._config.ship_obj_fn(os.path.join("images", THROB_IMAGE))
@@ -361,7 +389,15 @@ class FilesTab(MainWindowTab):
 
             self.emit("submit-rpc-job", job, prt)
 
-    def _refresh_local(self, *_args):
+    def _refresh_local(self, _button=None, _lfview=None):
+        '''
+        Refresh Local Button Handler.
+
+        :param _button: Button Widget, unused
+        :type _button: `:class:Gtk.Button`
+        :param _lfview: local fileview, unused
+        :type _lfview: `:class:LocalFileView`
+        '''
         self._local.refresh()
 
     def refresh_local(self):
@@ -370,6 +406,14 @@ class FilesTab(MainWindowTab):
         self._refresh_local()
 
     def _del(self, _button, _fileview):
+        '''
+        Delete Button Handler.
+
+        :param _button: Button Widget, unused
+        :type _button: `:class:Gtk.Button`
+        :param _fileview: local fileview, unused
+        :type _fileview: `:class:LocalFileView`
+        '''
         fname = self._local.get_selected_filename()
         if not fname:
             return
@@ -385,12 +429,23 @@ class FilesTab(MainWindowTab):
         self._local.refresh()
 
     def _upload(self, _button, _lfview):
+        '''
+        Upload Button Handler
+
+        :param _button: Button Widget, unused
+        :type _button: `:class:Gtk.Button`
+        :param _lfview: local fileview, unused
+        :type _lfview: `:class:LocalFileView`
+        '''
         fname = self._local.get_selected_filename()
         if not fname:
+            # button should not be enabled to allow this condition.
             return
 
         file_name = os.path.join(self._config.get("prefs", "download_dir"),
                                  fname)
+        # Need to validate that the file still exists or an exception could
+        # be fired.
 
         fnl = file_name.lower()
         if fnl.endswith(".jpg") or \
@@ -405,7 +460,7 @@ class FilesTab(MainWindowTab):
         port = psel.get_active_text()
 
         if self._remote:
-            station = self._remote.get_path()
+            station = self._remote.station
             self._remote.outstanding[fname] = os.stat(file_name).st_size
         else:
             station = ssel.get_active_text().upper()
@@ -414,8 +469,17 @@ class FilesTab(MainWindowTab):
             return
 
         self.emit("user-send-file", station, port, file_name, fname)
+        self.logger.info("_upload: emit user-send-file")
 
     def _download(self, _button, _rfview):
+        '''
+        Download Button Handler.
+
+        :param _button: Button Widget, unused
+        :type _button: `:class:Gtk.Button`
+        :param _rfview: remote fileview, unused
+        :type _rfview: `:class:RemoteFileView`
+        '''
         if not self._remote:
             return
 
@@ -441,6 +505,14 @@ class FilesTab(MainWindowTab):
         # FIXME: Need an event here
 
     def _delete(self, _button, _rfview):
+        '''
+        Delete Button Handler.
+
+        :param _button: Button Widget, unused
+        :type _button: `:class:Gtk.Button`
+        :param _rfview: remote fileview, unused
+        :type _rfview: `:class:RemoteFileView`
+        '''
         station = self._remote.get_path()
 
         dialog = inputdialog.TextInputDialog()


### PR DESCRIPTION
The driver XON/XOFF appears to be losing characters when used with actual radios.

Reverting back to software XON/XOFF and fixed the
case where software xon/xoff was discarding characters when the driver receive buffer was empty at the start of a read and something other than XON/XOFF was read from the radio.

d_rats/comm.py:
  Revert back to using software xon/xoff.
  Fix software xon/xoff to not discard characters.

d_rats/config.py:
  Only enable edit and remove buttons when an existing
  radio port is selected to prevent a crash.

d_rats/keyedlistwidget.py:
  Expose the treeview object as a property.