### PR TITLE
Make smtpd server optional

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.log,./.git,./temp*,./*venv,./docs/_build,./build,./locale,./*egg*
-ignore-words-list = drats,msdos,ro,speling,teh,warmup,inports
+ignore-words-list = drats,msdos,ro,speling,teh,warmup,inports,indx,Re-using,re-used


### PR DESCRIPTION
As of Python 3.12, the smtpd and asyncore libraries have been removed. This fix simply disables the SMTP server functionality in D-Rats until that mailsrv module can be reimplemented using a supported library.

d_rats/mailsrv.py:
    Disable smtpd for Python 3.12.