### PR TITLE
AGW: fixes a few issues with the AX.25 header when using an AGW modem.

### DIFF
--- a/d_rats/agw.py
+++ b/d_rats/agw.py
@@ -683,14 +683,14 @@ def transmit_data(conn, dcall, spath, data):
     # left one bit
     dst_str = "".join([chr(ord(x) << 1) for x in call])
     dst_str += encode_ssid(sid)
-    dst = dst_str.encode('utf-8', 'replace')
+    dst = bytes(dst_str, 'latin1')
 
     src_str = ""
     for scall in spath:
         call, sid = ssid(scall)
         src_str += "".join([chr(ord(x) << 1) for x in call])
         src_str += encode_ssid(sid, spath[-1] == scall)
-        src = src_str.encode('utf-8', 'replace')
+    src = bytes(src_str, 'latin1')
 
     data_frame = struct.pack("!B7s%isBB" % len(src),
                              0x00,    # Space for flag (?)

--- a/d_rats/agw.py
+++ b/d_rats/agw.py
@@ -696,7 +696,7 @@ def transmit_data(conn, dcall, spath, data):
                              0x00,    # Space for flag (?)
                              dst,     # Dest Call
                              src,     # Source Path
-                             0x3E,    # Info
+                             0x03,    # Unnumbered Info
                              0xF0)    # PID: No layer 3
     data_frame += data
 


### PR DESCRIPTION
Hi,

This PR fixes the AX.25 address / path encoding issues, and sets the frame type as Unnumbered Information (closes https://github.com/ham-radio-software/D-Rats/issues/298 ).

Locally tested.

Best regards,