### PR TITLE
AX25 encoding fixes.

### DIFF
--- a/changes/298.bugfix
+++ b/changes/298.bugfix
@@ -1,0 +1,2 @@
+Need to use AX.25 Unnumbered Information frames.
+Fix possible Filename corruption for AX.25 frames.

--- a/changes/304.bugfix
+++ b/changes/304.bugfix
@@ -1,0 +1,1 @@
+Make sure busybox is installed for MobaXterm installs

--- a/changes/305.bugfix
+++ b/changes/305.bugfix
@@ -1,0 +1,1 @@
+Possible data loss if special binary sequence sent over D-Star radio links

--- a/d-rats_in_mobaxterm_install.sh
+++ b/d-rats_in_mobaxterm_install.sh
@@ -16,7 +16,7 @@ export DEBIAN_FRONTEND
 $apt_get -y upgrade
 $apt_get -y install \
   aspell aspell-de aspell-en aspell-es aspell-it \
-  ffmpeg \
+  busybox ffmpeg \
   gedit gettext gettext-devel git gcc-core \
   libgtk3_0 libjpeg-devel libportaudio-devel \
   python39 python39-devel python39-gi python39-lxml \

--- a/d-rats_repeater.py
+++ b/d-rats_repeater.py
@@ -42,10 +42,10 @@ if not '_' in locals():
     import gettext
     _ = gettext.gettext
 
-import gi
+import gi  # type: ignore
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
-from gi.repository import GObject
+from gi.repository import Gtk  # type: ignore
+from gi.repository import GObject  # type: ignore
 
 # Make sure no one tries to run this with privileges.
 try:

--- a/d_rats/aprs_dprs.py
+++ b/d_rats/aprs_dprs.py
@@ -35,7 +35,7 @@ class AprsDprsCodes:
     APRS_ALTERNATE_SYMBOL_TABLE = '\\'
     APRS_ADVISORY_CODE = '\\<'
     APRS_CAR_CODE = '/>'
-    APRS_DIGI_CODD = '/#'
+    APRS_DIGI_CODE = '/#'
     APRS_DOT_CODE = '//'
     APRS_FALLBACK_CODE = '//'
     APRS_INFO_KIOSK_CODE = '\\?'
@@ -85,7 +85,7 @@ class AprsDprsCodes:
         and a list of regular APRS symbols
 
         `DPRS information <https://www.aprs-is.net/DPRS.aspx>`_
-        `DPRS Caldulator <http://www.aprs-is.net/DPRSCalc.aspx>_
+        `DPRS calculator <http://www.aprs-is.net/DPRSCalc.aspx>_
         '''
 
         if cls._dprs_to_aprs:

--- a/d_rats/wl2k.py
+++ b/d_rats/wl2k.py
@@ -11,11 +11,11 @@ import struct
 import time
 import re
 import random
-import gi
+import gi  # type: ignore
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import GLib
-from gi.repository import GObject
+from gi.repository import GLib  # type: ignore
+from gi.repository import GObject  # type: ignore
 
 from d_rats import version
 from d_rats import formgui
@@ -393,8 +393,9 @@ class WinLinkMessage:
         data = self.__lzh_content
 
         # filename \0 length(0) \0
-        header_str = self.__name + "\x00" + chr(len(data) & 0xFF) + "\x00"
-        header = header_str.encode('utf-8', 'replace')
+        data_len = chr(len(data) & 0xFF)
+        header = self.__name.encode('utf-8', 'replace') + b'\x00' + \
+            data_len.to_bytes(1,'little') + b'\x00'
         sock.send(struct.pack("<BB", FBB_BLOCK_HDR, len(header)) + header)
 
         checksum = 0
@@ -680,7 +681,7 @@ class WinLinkCMS:
             cs_octet += ord("\r")
             self._send(proposal)
 
-        cs_octet = ((~cs_octet & 0xFF) + 1)
+        cs_octet = (~cs_octet & 0xFF) + 1
         data_str = "F> %02X" % cs_octet
         self._send(data_str.encode('utf-8', 'replace'))
         resp = self._recv()

--- a/d_rats/yencode.py
+++ b/d_rats/yencode.py
@@ -3,7 +3,7 @@
 #
 # Copyright 2008 Dan Smith <dsmith@danplanet.com>
 #
-# Copyright 2021-2022 John. E. Malmberg - Python3 Conversion
+# Copyright 2021-2025 John. E. Malmberg - Python3 Conversion
 # # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -20,7 +20,22 @@
 from __future__ import absolute_import
 import sys
 
-DEFAULT_BANNED = b"\x11\x13\x1A\00\xFD\xFE\xFF"
+# 0X00 NULL
+# 0x11 XON
+# 0x13 XOFF
+# 0x76 XOFF (Alternate?)
+# 0x84 (packet loss notification)
+# 0xE7 (packet loss notification)
+# 0xFE (packet loss notification)
+# 0xFD Icom switch to radio control mode?
+# 0xFF Unknown
+#
+# 0xC0 FEND  Ax25 KISS Frame end
+# 0xDB FESC  Ax25 KISS Frame escape
+# 0xDC TFEND Ax25 KISS Transposed Frame End - Should not need blocking
+# 0xDD TFESC Ax25 KISS Transposed Frame Escape - Should not need blocking
+# looks like these frames may be passed through KISS links
+DEFAULT_BANNED = b"\x11\x13\x1A\00\x84\xE7\xFD\xFE\xFF\xC0\xDB"
 OFFSET = 64
 
 


### PR DESCRIPTION
Github user dscp46 discovered a potential data corruption in AX25 frame encoding and the control byte.

In Python3, you can not to some bit manipulations on the str data type as that has to contain valid Unicode characters.  One of the bytes types must be used instead.

d-rats_in_mobaxterm_install.sh:
  Reports that newerverions of mobaxterm do not have busybox
  pre-installed.

d-rats/agw.py:
d-rats/comm.py:
d-rats/wlk.py:
  Change to use bytes type for properly encoding binary.

Others:
  Spelling and pylint fixes found.