### PR TITLE
Add ACM ports to list of serial ports to support TH-D74

### DIFF
--- a/d_rats/dplatform_unix.py
+++ b/d_rats/dplatform_unix.py
@@ -85,7 +85,7 @@ class UnixPlatform(PlatformGeneric):
         :returns: The serial ports
         :rtype: list of str
         '''
-        return sorted(glob.glob("/dev/ttyS*") + glob.glob("/dev/ttyUSB*"))
+        return sorted(glob.glob("/dev/ttyS*") + glob.glob("/dev/ttyUSB*") + glob.glob("/dev/ttyACM*"))
 
     def os_version_string(self):
         '''


### PR DESCRIPTION
I am using Ubuntu 24.04.02 and a Kenwood TH-D74.

When connected via USB it appears at the serial port /dev/ttyACM0 and was not available in the list of ports in the radio config dialog. By adding /dev/ttyACM* to this list, I can select and use the radio.